### PR TITLE
Fix vote contract deployment

### DIFF
--- a/pages/[wallet]/[network]/new/[type]/[contractType].tsx
+++ b/pages/[wallet]/[network]/new/[type]/[contractType].tsx
@@ -685,8 +685,8 @@ const ContractDeployForm = <TContract extends ValidContractClass>({
                     }
                     defaultValue={0}
                     min={0}
-                    step={0.01}
-                    max={1}
+                    step={1}
+                    max={100}
                   >
                     <NumberInputField />
                     <NumberInputStepper>
@@ -697,8 +697,9 @@ const ContractDeployForm = <TContract extends ValidContractClass>({
                   <FormHelperText>
                     The fraction of the total voting power that is required for
                     a proposal to pass. A value of 0 indicates that no voting
-                    power is sufficient, whereas a value of 1 indicates that the
-                    entirety of voting power must vote for a proposal to pass.
+                    power is sufficient, whereas a value of 100 indicates that
+                    the entirety of voting power must vote for a proposal to
+                    pass.
                   </FormHelperText>
                   <FormErrorMessage>
                     {


### PR DESCRIPTION
Quorum doesn't accept decimals, only a number between 0-100.