### PR TITLE
Enumerable check

### DIFF
--- a/contract-ui/tabs/nfts/components/mint-button.tsx
+++ b/contract-ui/tabs/nfts/components/mint-button.tsx
@@ -1,10 +1,10 @@
 import { NFTMintForm } from "./mint-form";
 import { Icon, useDisclosure } from "@chakra-ui/react";
 import { NFTContract } from "@thirdweb-dev/react";
-import { ExtensionDetectButton } from "components/buttons/ExtensionDetectButton";
+import { extensionDetectedState } from "components/buttons/ExtensionDetectButton";
 import React from "react";
 import { FiPlus } from "react-icons/fi";
-import { Drawer } from "tw-components";
+import { Button, Drawer } from "tw-components";
 
 interface NFTMintButtonProps {
   contract: NFTContract;
@@ -15,6 +15,11 @@ export const NFTMintButton: React.FC<NFTMintButtonProps> = ({
   ...restButtonProps
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const detectedState = extensionDetectedState({
+    contract,
+    feature: ["ERC721Mintable", "ERC1155Mintable"],
+  });
 
   return (
     <>
@@ -27,16 +32,16 @@ export const NFTMintButton: React.FC<NFTMintButtonProps> = ({
       >
         <NFTMintForm contract={contract} />
       </Drawer>
-      <ExtensionDetectButton
-        colorScheme="primary"
-        leftIcon={<Icon as={FiPlus} />}
-        {...restButtonProps}
-        onClick={onOpen}
-        contract={contract}
-        feature={["ERC721Mintable", "ERC1155Mintable"]}
-      >
-        Mint
-      </ExtensionDetectButton>
+      {detectedState === "enabled" && (
+        <Button
+          colorScheme="primary"
+          leftIcon={<Icon as={FiPlus} />}
+          {...restButtonProps}
+          onClick={onOpen}
+        >
+          Mint
+        </Button>
+      )}
     </>
   );
 };

--- a/contract-ui/tabs/nfts/page.tsx
+++ b/contract-ui/tabs/nfts/page.tsx
@@ -6,6 +6,7 @@ import { Erc721, Erc1155 } from "@thirdweb-dev/sdk";
 import { PotentialContractInstance } from "contract-ui/types/types";
 import React from "react";
 import { Card, Heading, LinkButton, Text } from "tw-components";
+import { extensionDetectedState } from "components/buttons/ExtensionDetectButton";
 
 interface NftOverviewPageProps {
   contractAddress?: string;
@@ -19,18 +20,23 @@ export const ContractNFTPage: React.FC<NftOverviewPageProps> = ({
 
   const detectedContract = detectNFTContractInstance(contract.contract);
 
+  const detectedState = extensionDetectedState({
+    contract,
+    feature: ["ERC721Enumerable", "ERC1155Enumerable"],
+  });
+
   if (contract.isLoading) {
     // TODO build a skeleton for this
     return <div>Loading...</div>;
   }
 
-  if (!detectedContract) {
+  if (!detectedContract || detectedState === "disabled") {
     return (
       <Card as={Flex} flexDir="column" gap={3}>
         {/* TODO  extract this out into it's own component and make it better */}
-        <Heading size="subtitle.md">No NFT extension enabled</Heading>
+        <Heading size="subtitle.md">No Enumerable extension enabled</Heading>
         <Text>
-          To enable NFT features you will have to extend the required interfaces
+          To being able to see the list of the NFTs minted on your contract, you will have to extend the required interfaces
           in your contract.
         </Text>
 
@@ -40,15 +46,15 @@ export const ContractNFTPage: React.FC<NftOverviewPageProps> = ({
           <ButtonGroup colorScheme="purple" size="sm" variant="solid">
             <LinkButton
               isExternal
-              href="https://portal.thirdweb.com/thirdweb-deploy/contract-features/erc721"
+              href="https://portal.thirdweb.com/thirdweb-deploy/contract-extensions/erc721#erc721enumerable"
             >
-              ERC721
+              ERC721Enumerable
             </LinkButton>
             <LinkButton
               isExternal
-              href="https://portal.thirdweb.com/thirdweb-deploy/contract-features/erc1155"
+              href="https://portal.thirdweb.com/thirdweb-deploy/contract-extensions/erc721#erc721enumerable"
             >
-              ERC1155
+              ERC1155Enumerable
             </LinkButton>
           </ButtonGroup>
         </Flex>
@@ -62,8 +68,9 @@ export const ContractNFTPage: React.FC<NftOverviewPageProps> = ({
         <Heading size="title.sm">Contract NFTs</Heading>
         <NFTMintButton contract={detectedContract} />
       </Flex>
-      {/* TODO check if this is supported before rendering it */}
-      <NftGetAllTable contract={detectedContract} />
+      {detectedState === "enabled" && (
+        <NftGetAllTable contract={detectedContract} />
+      ) }
     </Flex>
   );
 };


### PR DESCRIPTION
Not sure about the implementation here.

Right now we're checking ERC721/ERC1155 for the tab and giving the user a checkmark, but we actually care about Enumerable for that tab to show anything.

might be worth showing the tab always but without the checkmark? or tab always but checkmark when enumerable?

for now, I left it so it shows the tab with checkmark when ERC721/ERC1155 but it tells you that you need to implement enumerable, also hides the Mint button if the contract is not mintable