### PR TITLE
Fix useContractCall code snippet

### DIFF
--- a/contract-ui/tabs/code/components/code-overview.tsx
+++ b/contract-ui/tabs/code/components/code-overview.tsx
@@ -60,7 +60,7 @@ export default function Component() {
 
   const call = async () => {
     try{
-      const data = await {{function}}({ {{args}} });
+      const data = await {{function}}([ {{args}} ]);
       console.log("contract call successs", data);
     }catch(err){
       console.error("contract call failure", err);


### PR DESCRIPTION
This works fine in the @dev version of the SDK, would be good to make it a stable build.

Not super critical to do before merging since current state is broken but would be good.