### PR TITLE
always show verify on etherscan button

### DIFF
--- a/contract-ui/tabs/sources/page.tsx
+++ b/contract-ui/tabs/sources/page.tsx
@@ -216,11 +216,9 @@ export const CustomContractSourcesPage: React.FC<
           <Heading size="title.sm" flex={1}>
             Sources
           </Heading>
-          {!prebuiltSource && (
-            <Button variant="solid" colorScheme="purple" onClick={onOpen}>
-              Verify on {blockExplorerName(chainId)}
-            </Button>
-          )}
+          <Button variant="solid" colorScheme="purple" onClick={onOpen}>
+            Verify on {blockExplorerName(chainId)}
+          </Button>
         </Flex>
         <Card>
           <SourcesPanel sources={sources} abi={abi} />


### PR DESCRIPTION
if already verified, it'll tell you once you click the button
(we want this to verify our own implementations we deploy)

as a next step we can fetch verification status first and show a "already verified" label instead