### PR TITLE
Add Web3Button option to code tab

### DIFF
--- a/components/contract-tabs/code/CodeSegment.tsx
+++ b/components/contract-tabs/code/CodeSegment.tsx
@@ -6,7 +6,7 @@ import { SiPython } from "@react-icons/all-files/si/SiPython";
 import { SiReact } from "@react-icons/all-files/si/SiReact";
 import { SiTypescript } from "@react-icons/all-files/si/SiTypescript";
 import { Dispatch, SetStateAction, useMemo } from "react";
-import { Button, CodeBlock } from "tw-components";
+import { Button, CodeBlock, Text, TrackedLink } from "tw-components";
 import { ComponentWithChildren } from "types/component-with-children";
 
 interface ICodeSegment {
@@ -124,6 +124,19 @@ export const CodeSegment: React.FC<ICodeSegment> = ({
             : activeEnvironment
         }
       />
+      {activeEnvironment === "web3button" && (
+        <Text>
+          <TrackedLink
+            href="https://portal.thirdweb.com/ui-components/web3button"
+            isExternal
+            category="code-tab"
+            label="web3button"
+          >
+            Read the full documentation on Web3Button
+          </TrackedLink>
+          .
+        </Text>
+      )}
     </Stack>
   );
 };

--- a/components/contract-tabs/code/CodeSegment.tsx
+++ b/components/contract-tabs/code/CodeSegment.tsx
@@ -25,6 +25,12 @@ const Environments: SupportedEnvironment[] = [
     colorScheme: "purple",
   },
   {
+    environment: "web3button",
+    title: "Web3Button",
+    icon: SiReact,
+    colorScheme: "purple",
+  },
+  {
     environment: "javascript",
     title: "JavaScript",
     icon: SiJavascript,
@@ -112,7 +118,8 @@ export const CodeSegment: React.FC<ICodeSegment> = ({
         language={
           isInstallCommand
             ? "bash"
-            : activeEnvironment === "react"
+            : activeEnvironment === "react" ||
+              activeEnvironment === "web3button"
             ? "jsx"
             : activeEnvironment
         }

--- a/components/contract-tabs/code/ContractCode.tsx
+++ b/components/contract-tabs/code/ContractCode.tsx
@@ -167,7 +167,11 @@ export const ContractCode: React.FC<IContractCode> = ({
               <Text>First, install the latest version of the SDK.</Text>
               <CodeBlock
                 language="bash"
-                code={INSTALL_COMMANDS[ecosystem][environment]}
+                code={
+                  INSTALL_COMMANDS[ecosystem][
+                    environment !== "web3button" ? environment : "react"
+                  ]
+                }
               />
             </>
           )}

--- a/components/contract-tabs/code/types.ts
+++ b/components/contract-tabs/code/types.ts
@@ -1,6 +1,7 @@
 export type Environment =
   | "javascript"
   | "typescript"
+  | "web3button"
   | "react"
   | "python"
   | "go";

--- a/contract-ui/tabs/code/components/code-overview.tsx
+++ b/contract-ui/tabs/code/components/code-overview.tsx
@@ -16,6 +16,7 @@ const COMMANDS = {
   install: {
     javascript: "npm install @thirdweb-dev/sdk ethers",
     react: "npm install @thirdweb-dev/react @thirdweb-dev/sdk ethers",
+    web3button: "npm install @thirdweb-dev/react @thirdweb-dev/sdk ethers",
     python: "pip install thirdweb-sdk",
     go: "go get github.com/thirdweb-dev/go-sdk/thirdweb",
   },
@@ -29,6 +30,20 @@ const contract = await sdk.getContract("{{contract_address}}");`,
 export default function Component() {
   const { contract } = useContract("{{contract_address}}");
   // Now you can use the contract in the rest of the component
+}`,
+    web3button: `import { Web3Button } from "@thirdweb-dev/react";
+
+export default function Component() {
+  return (
+    <Web3Button
+      contractAddress="{{contract_address}}"
+      action={(contract) => {
+        // Any action with your contract
+      }}
+    >
+      Do something
+    </Web3Button>
+  )
 }`,
     python: `from thirdweb import ThirdwebSDK
 
@@ -67,6 +82,20 @@ export default function Component() {
       console.error("contract call failure", err);
     }
   }
+}`,
+    web3button: `import { Web3Button } from "@thirdweb-dev/react";
+
+export default function Component() {
+  return (
+    <Web3Button
+      contractAddress="{{contract_address}}"
+      action={(contract) => {
+        contract.call("{{function}}", {{args}})
+      }}
+    >
+      {{function}}
+    </Web3Button>
+  )
 }`,
     python: `data = contract.call("{{function}}", {{args}})`,
     go: `data, err := contract.Call("{{function}}", {{args}})`,
@@ -158,7 +187,7 @@ export const CodeOverview: React.FC<CodeOverviewProps> = ({ contract }) => {
         </Flex>
         <Text>
           Once you setup your contract, you can read data from contract
-          functions as follows.
+          functions as follows:
         </Text>
         <Flex>
           <Box>
@@ -193,7 +222,7 @@ export const CodeOverview: React.FC<CodeOverviewProps> = ({ contract }) => {
           <Heading size="title.sm">Writing Data</Heading>
         </Flex>
         <Text>
-          And you can also make write function calls with the following setup
+          And you can also make write function calls with the following setup:
         </Text>
         <Flex>
           <Box>


### PR DESCRIPTION
This feels good enough for now, we _could_ have the Web3Button appear below the code, but will need passing more props to the CodeSegment component which I don't think it's worth.

I think this helps with discovery and the link to doc completes the flow.