### PR TITLE
Updated metadescription

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -252,7 +252,7 @@ function ConsoleApp({ Component, pageProps }: AppPropsWithLayout) {
         <DefaultSeo
           defaultTitle="thirdweb: The complete web3 development framework"
           titleTemplate="%s | thirdweb"
-          description="Build, launch, and manage web3 apps with thirdweb's powerful SDKs, audited smart contracts, and developer tools—for Ethereum, Polygon, Solana, & more."
+          description="Build web3 apps easily with thirdweb's powerful SDKs, audited smart contracts, and developer tools—for Ethereum, Polygon, Solana, & more. Try now."
           additionalLinkTags={[
             {
               rel: "icon",
@@ -262,7 +262,7 @@ function ConsoleApp({ Component, pageProps }: AppPropsWithLayout) {
           openGraph={{
             title: "thirdweb: The complete web3 development framework",
             description:
-              "Build, launch, and manage web3 apps with thirdweb's powerful SDKs, audited smart contracts, and developer tools—for Ethereum, Polygon, Solana, & more.",
+              "Build web3 apps easily with thirdweb's powerful SDKs, audited smart contracts, and developer tools—for Ethereum, Polygon, Solana, & more. Try now.",
             type: "website",
             locale: "en_US",
             url: "https://thirdweb.com",


### PR DESCRIPTION
Google didn't take our metadesc because I wrote "build, launch, and manage web3 apps..." - needs to include copy on the homepage so changed this to "build web3 apps easily" & will be more likely to use it.

"Build, launch, manage" is better messaging & we can switch back to it once we update homepage copy (there have been branding discussions here)