### PR TITLE
optimize-newsletter: drop react-hook-form

### DIFF
--- a/components/homepage/sections/NewsletterSection.tsx
+++ b/components/homepage/sections/NewsletterSection.tsx
@@ -7,16 +7,35 @@ import {
   Input,
   Stack,
 } from "@chakra-ui/react";
-import { useForm } from "react-hook-form";
+import { useState } from "react";
 import { MdMarkEmailRead } from "react-icons/md";
 import { Button, Text } from "tw-components";
 
 export const NewsletterSection = () => {
-  const form = useForm({
-    defaultValues: {
-      email: "",
-    },
-  });
+  const [email, setEmail] = useState("");
+  const [isValidEmail, setIsValidEmail] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    // ignore invalid email
+    if (!isValidEmail) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await fetch("/api/email-signup", {
+        method: "POST",
+        body: JSON.stringify({ email }),
+      });
+      setEmail("");
+    } catch (err) {
+      console.error(err);
+    }
+
+    setIsSubmitting(false);
+  }
 
   return (
     <Box bg="rgba(0,0,0,.6)" zIndex="100">
@@ -41,19 +60,7 @@ export const NewsletterSection = () => {
             </Stack>
           </Stack>
 
-          <form
-            onSubmit={form.handleSubmit(async (data) => {
-              try {
-                await fetch("/api/email-signup", {
-                  method: "POST",
-                  body: JSON.stringify({ email: data.email }),
-                });
-                form.setValue("email", "");
-              } catch (err) {
-                console.error(err);
-              }
-            })}
-          >
+          <form onSubmit={(e) => e.preventDefault()}>
             <Flex gap={0} minW={{ base: "100%", md: "350px" }}>
               <FormControl isRequired>
                 <Input
@@ -64,16 +71,26 @@ export const NewsletterSection = () => {
                   _hover={{ borderColor: "purple.500" }}
                   _focus={{ borderColor: "purple.500" }}
                   placeholder="Enter your email"
-                  {...form.register("email")}
+                  value={email}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      handleSubmit();
+                    }
+                  }}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                    setIsValidEmail(e.target.validity.valid);
+                  }}
                   autoComplete="email"
                 />
               </FormControl>
               <Button
                 borderLeftRadius={0}
                 flexShrink={0}
-                isLoading={form.formState.isSubmitting}
+                isLoading={isSubmitting}
                 type="submit"
                 mr={2}
+                onClick={handleSubmit}
                 colorScheme="purple"
               >
                 Sign up


### PR DESCRIPTION
## Why?

The newsletter form only has a single input element as shown below

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/22043396/206837109-a31df604-bbb0-48e6-979a-a2b43c8f4190.png">

* using `react-hook-form` for handling a single input is not necessary 
* removing `react-hook-form` from the newsletter will reduce JS bundle size by a 22kB on any page that use it (unless of course, that page has other components using `react-hook-form` )


### Before ( landing page )
<img width="400" alt="image" src="https://user-images.githubusercontent.com/22043396/206838239-5fc94eeb-e42f-414f-b58b-fab925a23acb.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/22043396/206838284-362452be-b71b-4610-900f-a82daa192085.png">


### After ( landing page ) - 22kB JS reduction

<img width="400" alt="image" src="https://user-images.githubusercontent.com/22043396/206838335-e5d29822-8daa-4dfe-b3ed-9793661df9f4.png">

---

## Code changes 

* `react-hook-form` replaced with idiomatic code for handling submission - Yes, Its a bit verbose but reduces a lot of code in the final bundle size
* functionality remains the same ( prevent submission on invalid email, preventDefault for submit event, clear input after submission, loading state indicator )

<br/>