### PR TITLE
Landing Page: Fix Aurora Images

### DIFF
--- a/components/homepage/sections/CLISection.tsx
+++ b/components/homepage/sections/CLISection.tsx
@@ -39,6 +39,7 @@ export const CLISection = () => {
     <HomepageSection
       id="developers"
       py={{ base: 24, md: 48 }}
+      topGradient
       middleGradient
       bottomGradient
     >

--- a/components/product-pages/homepage/HomepageSection.tsx
+++ b/components/product-pages/homepage/HomepageSection.tsx
@@ -27,13 +27,12 @@ export const HomepageSection: ComponentWithChildren<IHomepageSection> = ({
       zIndex={2}
       {...restBoxProps}
     >
-      {topGradient && <AuroraBg orientation="top" />}
-
-      {middleGradient && <AuroraBg orientation="middle" />}
-
-      {bottomGradient && <AuroraBg orientation="bottom" />}
-
       <Container zIndex={1} position="relative" maxW="container.page" id={id}>
+        {/* aurora effect */}
+        {topGradient && <AuroraBg orientation="top" />}
+        {middleGradient && <AuroraBg orientation="middle" />}
+        {bottomGradient && <AuroraBg orientation="bottom" />}
+
         {children}
 
         {bottomPattern && (
@@ -118,8 +117,8 @@ const AuroraBg: React.FC<AuroraBgProps> = ({ orientation }) => {
       willChange="opacity"
       pointerEvents="none"
       position="absolute"
-      w="400%"
-      maxW={{ base: "200vw", md: "120vw", "2xl": "80vw" }}
+      maxW="none"
+      w={{ base: "400%", md: "200%" }}
       left="50%"
       top={
         orientation === "top" ? "0" : orientation === "bottom" ? "100%" : "50%"


### PR DESCRIPTION
Hi @jnsdls,

This PR implements the changes I suggested in https://github.com/thirdweb-dev/dashboard/issues/703#issuecomment-1340070587 

With this code change, The issue of Aurora being too small on a regular desktop screen is fixed and its size goes back to what it was originally before we replaced the CSS blur with the Aurora image, and looks good across all widths

I've also added a missing Aurora Image in CLISection 

<br/>

## Before: (Hero Section)

Problem: The Aurora looks a bit odd and out of place because of its smaller size

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/22043396/206995781-c4d37f9d-6c47-4d69-83e8-67ccf4de4eeb.png">

## After this commit: (Hero Section)

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/22043396/206995820-d7b17118-5f9e-4fd8-bf02-aaec65a67c22.png">


### What it looked like before CSS blur was changed to an image

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/22043396/206997836-119e24ba-f69b-4ca6-b288-fe1d943e4a2d.png">


<br/>
<br/>

---

<br/>
<br/>

### Before: (CLI Section)

problem: The UI looks too dark because it's missing an aurora image on top ( This section used to be properly lit up before we changed CSS blur to image - see this [preview](https://thirdweb-www-git-imgbot-thirdweb.vercel.app/) )

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/22043396/206996118-a328be5e-84e2-47e1-86d5-ef0b66d20a25.png">

### After this commit: (CLI Section)

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/22043396/206997310-845407de-9985-4d8f-9311-05e4167f3a45.png">

### What It looked like before CSS Blur was changed to Image

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/22043396/206997534-284cc950-aa53-4a85-b773-7832ada15c81.png">

