### PR TITLE
Huge JS bundle size optimization! 🎉

### DIFF
--- a/components/contract-components/contract-table-v2/index.tsx
+++ b/components/contract-components/contract-table-v2/index.tsx
@@ -46,7 +46,6 @@ import { FiArrowRight } from "react-icons/fi";
 import { Column, Row, useTable } from "react-table";
 import invariant from "tiny-invariant";
 import {
-  AddressCopyButton,
   Card,
   Drawer,
   Heading,
@@ -55,6 +54,7 @@ import {
   TrackedIconButton,
   TrackedLink,
 } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 import { ComponentWithChildren } from "types/component-with-children";
 import {
   DashboardSolanaNetwork,

--- a/components/contract-components/tables/deployed-contracts.tsx
+++ b/components/contract-components/tables/deployed-contracts.tsx
@@ -45,7 +45,6 @@ import { FiArrowRight, FiPlus } from "react-icons/fi";
 import { IoFilterSharp } from "react-icons/io5";
 import { Column, useFilters, useGlobalFilter, useTable } from "react-table";
 import {
-  AddressCopyButton,
   Badge,
   Card,
   ChakraNextLink,
@@ -54,6 +53,7 @@ import {
   LinkButton,
   Text,
 } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 import { ComponentWithChildren } from "types/component-with-children";
 import { getNetworkFromChainId } from "utils/network";
 import { shortenIfAddress } from "utils/usedapp-external";

--- a/components/contract-components/tables/deployed-programs.tsx
+++ b/components/contract-components/tables/deployed-programs.tsx
@@ -7,13 +7,8 @@ import { FeatureIconMap } from "constants/mappings";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { FiPlus } from "react-icons/fi";
-import {
-  AddressCopyButton,
-  Badge,
-  Heading,
-  LinkButton,
-  Text,
-} from "tw-components";
+import { Badge, Heading, LinkButton, Text } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 import { SupportedSolanaNetworkToUrlMap } from "utils/network";
 
 interface DeployedProgramsProps {

--- a/components/custom-contract/contract-header/metadata-header.tsx
+++ b/components/custom-contract/contract-header/metadata-header.tsx
@@ -5,7 +5,8 @@ import { ContractBadge } from "components/badges/contract-badge";
 import { NextSeo } from "next-seo";
 import { StaticImageData } from "next/image";
 import { useMemo } from "react";
-import { AddressCopyButton, Heading, Text } from "tw-components";
+import { Heading, Text } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 
 interface MetadataHeaderProps {
   isLoaded: boolean;

--- a/contexts/error-handler.tsx
+++ b/contexts/error-handler.tsx
@@ -16,14 +16,8 @@ import {
   useState,
 } from "react";
 import { FiAlertTriangle, FiCheck, FiCopy } from "react-icons/fi";
-import {
-  AddressCopyButton,
-  Button,
-  Drawer,
-  Heading,
-  LinkButton,
-  Text,
-} from "tw-components";
+import { Button, Drawer, Heading, LinkButton, Text } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 import { ComponentWithChildren } from "types/component-with-children";
 import { parseErrorToMessage } from "utils/errorParser";
 

--- a/contract-ui/tabs/listings/components/listing-drawer.tsx
+++ b/contract-ui/tabs/listings/components/listing-drawer.tsx
@@ -18,15 +18,8 @@ import type {
 } from "@thirdweb-dev/sdk/evm";
 import { BigNumber } from "ethers";
 import { useMemo } from "react";
-import {
-  AddressCopyButton,
-  Badge,
-  Card,
-  CodeBlock,
-  Drawer,
-  Heading,
-  Text,
-} from "tw-components";
+import { Badge, Card, CodeBlock, Drawer, Heading, Text } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 import { NFTMedia } from "tw-components/nft-media";
 
 interface NFTDrawerProps {

--- a/contract-ui/tabs/listings/components/table.tsx
+++ b/contract-ui/tabs/listings/components/table.tsx
@@ -37,7 +37,8 @@ import {
   MdNavigateNext,
 } from "react-icons/md";
 import { Cell, Column, usePagination, useTable } from "react-table";
-import { AddressCopyButton, Button, Card, Heading, Text } from "tw-components";
+import { Button, Card, Heading, Text } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 
 type ListingMetadata = AuctionListing | DirectListing;
 

--- a/contract-ui/tabs/nfts/components/table.tsx
+++ b/contract-ui/tabs/nfts/components/table.tsx
@@ -29,7 +29,8 @@ import {
   MdNavigateNext,
 } from "react-icons/md";
 import { CellProps, Column, usePagination, useTable } from "react-table";
-import { AddressCopyButton, Card, Heading, Text } from "tw-components";
+import { Card, Heading, Text } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 
 interface ContractOverviewNFTGetAllProps {
   contract: NFTContract;

--- a/core-ui/nft-drawer/nft-drawer.tsx
+++ b/core-ui/nft-drawer/nft-drawer.tsx
@@ -13,15 +13,8 @@ import {
 import { PublicKey } from "@solana/web3.js";
 import type { NFT } from "@thirdweb-dev/sdk";
 import React from "react";
-import {
-  AddressCopyButton,
-  Badge,
-  Card,
-  CodeBlock,
-  Drawer,
-  Heading,
-  Text,
-} from "tw-components";
+import { Badge, Card, CodeBlock, Drawer, Heading, Text } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 import { NFTMediaWithEmptyState } from "tw-components/nft-media";
 
 interface NFTDrawerProps {

--- a/program-ui/nft/components/table.tsx
+++ b/program-ui/nft/components/table.tsx
@@ -30,7 +30,8 @@ import {
   MdNavigateNext,
 } from "react-icons/md";
 import { CellProps, Column, usePagination, useTable } from "react-table";
-import { AddressCopyButton, Card, Heading, Text } from "tw-components";
+import { Card, Heading, Text } from "tw-components";
+import { AddressCopyButton } from "tw-components/AddressCopyButton";
 import { shortenIfAddress } from "utils/usedapp-external";
 
 export const NFTGetAllTable: React.FC<{

--- a/tw-components/AddressCopyButton.tsx
+++ b/tw-components/AddressCopyButton.tsx
@@ -1,0 +1,104 @@
+import {
+  Button,
+  ButtonProps,
+  PossibleButtonSize,
+  buttonSizesMap,
+} from "./button";
+import { Card } from "./card";
+import { Text } from "./text";
+import { Icon, Tooltip, useClipboard, useToast } from "@chakra-ui/react";
+import { useTrack } from "hooks/analytics/useTrack";
+import React, { useEffect } from "react";
+import { FiCopy } from "react-icons/fi";
+
+/**
+ * 📝 @TODO
+ * Write a custom alternative to `shortenIfAddress` function
+ * Why? - it imports a lot of other stuff which can not be tree-shaken
+ */
+import { shortenIfAddress } from "utils/usedapp-external";
+
+/**
+ * ❗️❗️❗️ @DANGER
+ * Importing this component will result in a HUGE bundle size because of `shortenIfAddress`
+ */
+
+interface AddressCopyButtonProps extends Omit<ButtonProps, "onClick" | "size"> {
+  address?: string;
+  noIcon?: boolean;
+  size?: PossibleButtonSize;
+  tokenId?: boolean;
+}
+
+export const AddressCopyButton: React.FC<AddressCopyButtonProps> = ({
+  address,
+  noIcon,
+  flexGrow = 0,
+  size = "sm",
+  borderRadius = "md",
+  variant = "outline",
+  tokenId,
+  ...restButtonProps
+}) => {
+  const { onCopy, setValue } = useClipboard(address || "");
+
+  useEffect(() => {
+    if (address) {
+      setValue(address);
+    }
+  }, [address, setValue]);
+
+  const trackEvent = useTrack();
+  const toast = useToast();
+
+  return (
+    <Tooltip
+      p={0}
+      bg="transparent"
+      boxShadow="none"
+      label={
+        <Card py={2} px={4}>
+          <Text size="label.sm">
+            Copy {tokenId ? "Token ID" : "address"} to clipboard
+          </Text>
+        </Card>
+      }
+    >
+      <Button
+        flexGrow={flexGrow}
+        size={size}
+        borderRadius={borderRadius}
+        variant={variant}
+        {...restButtonProps}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          onCopy();
+          toast({
+            variant: "solid",
+            position: "bottom",
+            title: `${tokenId ? "Token ID" : "Address"} copied.`,
+            status: "success",
+            duration: 5000,
+            isClosable: true,
+          });
+          if (tokenId) {
+            trackEvent({
+              category: "tokenid_button",
+              action: "copy",
+              tokenId: address,
+            });
+          } else {
+            trackEvent({ category: "address_button", action: "copy", address });
+          }
+        }}
+        leftIcon={noIcon ? undefined : <Icon boxSize={3} as={FiCopy} />}
+        fontFamily="mono"
+      >
+        <Text size={`label.${buttonSizesMap[size]}`}>
+          {shortenIfAddress(address)}
+        </Text>
+      </Button>
+    </Tooltip>
+  );
+};

--- a/tw-components/button.tsx
+++ b/tw-components/button.tsx
@@ -1,6 +1,4 @@
-import { Card } from "./card";
 import { ChakraNextLink } from "./link";
-import { Text } from "./text";
 import { convertFontSizeToCSSVar } from "./utils/typography";
 import {
   Button as ChakraButton,
@@ -10,18 +8,14 @@ import {
   IconButtonProps,
   LightMode,
   Link,
-  Tooltip,
   forwardRef,
   useButtonGroup,
-  useClipboard,
-  useToast,
 } from "@chakra-ui/react";
 import { Link as LocationLink, useMatch } from "@tanstack/react-location";
 import { useTrack } from "hooks/analytics/useTrack";
-import React, { useEffect } from "react";
-import { FiCopy, FiExternalLink } from "react-icons/fi";
+import React from "react";
+import { FiExternalLink } from "react-icons/fi";
 import { fontWeights, letterSpacings, lineHeights } from "theme/typography";
-import { shortenIfAddress } from "utils/usedapp-external";
 
 export const buttonSizesMap = {
   xs: "sm",
@@ -164,83 +158,3 @@ export const TrackedIconButton = forwardRef<TrackedIconButtonProps, "button">(
 );
 
 TrackedIconButton.displayName = "TrackedIconButton";
-
-interface AddressCopyButtonProps extends Omit<ButtonProps, "onClick" | "size"> {
-  address?: string;
-  noIcon?: boolean;
-  size?: PossibleButtonSize;
-  tokenId?: boolean;
-}
-
-export const AddressCopyButton: React.FC<AddressCopyButtonProps> = ({
-  address,
-  noIcon,
-  flexGrow = 0,
-  size = "sm",
-  borderRadius = "md",
-  variant = "outline",
-  tokenId,
-  ...restButtonProps
-}) => {
-  const { onCopy, setValue } = useClipboard(address || "");
-
-  useEffect(() => {
-    if (address) {
-      setValue(address);
-    }
-  }, [address, setValue]);
-
-  const trackEvent = useTrack();
-  const toast = useToast();
-
-  return (
-    <Tooltip
-      p={0}
-      bg="transparent"
-      boxShadow="none"
-      label={
-        <Card py={2} px={4}>
-          <Text size="label.sm">
-            Copy {tokenId ? "Token ID" : "address"} to clipboard
-          </Text>
-        </Card>
-      }
-    >
-      <Button
-        flexGrow={flexGrow}
-        size={size}
-        borderRadius={borderRadius}
-        variant={variant}
-        {...restButtonProps}
-        onClick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          onCopy();
-          toast({
-            variant: "solid",
-            position: "bottom",
-            title: `${tokenId ? "Token ID" : "Address"} copied.`,
-            status: "success",
-            duration: 5000,
-            isClosable: true,
-          });
-          if (tokenId) {
-            trackEvent({
-              category: "tokenid_button",
-              action: "copy",
-              tokenId: address,
-            });
-          } else {
-            trackEvent({ category: "address_button", action: "copy", address });
-          }
-        }}
-        leftIcon={noIcon ? undefined : <Icon boxSize={3} as={FiCopy} />}
-        fontFamily="mono"
-      >
-        <Text size={`label.${buttonSizesMap[size]}`}>
-          {shortenIfAddress(address)}
-        </Text>
-      </Button>
-    </Tooltip>
-  );
-};

--- a/tw-components/index.ts
+++ b/tw-components/index.ts
@@ -9,3 +9,9 @@ export * from "./heading";
 export * from "./text";
 export * from "./form";
 export * from "./menu";
+
+/**
+ * ❗️❗️❗️ @DANGER
+ * Do not export `AddressCopyButton` from here
+ * It will result in a HUGE bundle size
+ */


### PR DESCRIPTION
# Huge JS bundle size optimization! 🎉

Path | BEFORE ( JS size ) | AFTER ( JS size ) | JS Reduction %
-- | -- | -- | --
/ | 927 kB | 344 kB | -62%
/dashboards | 896 kB | 314 kB | -65%
/deploy | 896 kB | 314 kB | -65%
/sdk | 906 kB | 324 kB | -64%
/ui-components | 896 kB | 314 kB | -65%
/404 | 878 kB | 296 kB | -66%
/about | 896 kB | 314 kB | -65%
/auth | 905 kB | 323 kB | -64%
/network/solana | 899 kB | 317 kB | -65%
/release | 897 kB | 315 kB | -65%
/smart-contracts | 896 kB | 314 kB | -65%
/solutions/commerce | 904 kB | 322 kB | -64%
/solutions/gaming | 915 kB | 333 kB | -64%
/storage | 895 kB | 313 kB | -65%
/hackathon/solanathon | 898 kB | 316 kB | -65%
/_og/profile | 882 kB | 314 kB | -64%

<br/>

## What was the issue?

* The Tree shaking does not work properly when `AddressCopyButton` is involved in the import/export

* The root cause of the issue is the function `shortenIfAddress` used in it - when importing that function it adds a TON of web3 dependencies

<br/>

## Code Change

* Minimal Code Change - just moved `AddressCopyButton` to a new file and removed its export from `tw-components/index.ts` to keep it separate from other exports
* With this change, Any page that does not use `AddressCopyButton` sees a dramatic improvement in JS bundle size

<br/>

## Further Improvements for `AddressCopyButton`

* If we can write a custom implementation of `shortenIfAddress` - that would improve the bundle sizes on pages where `AddressCopyButton` is used as well 