### PR TITLE
Fix emotion's string not allowed as css prop error in UpdateNotice

### DIFF
--- a/core-ui/update-notice/update-notice.tsx
+++ b/core-ui/update-notice/update-notice.tsx
@@ -1,4 +1,5 @@
 import { Flex, Icon } from "@chakra-ui/react";
+import { css } from "@emotion/react";
 import { SiJavascript } from "@react-icons/all-files/si/SiJavascript";
 // import { SiGo } from "@react-icons/all-files/si/SiGo";
 // import { SiPython } from "@react-icons/all-files/si/SiPython";
@@ -64,7 +65,7 @@ export const UpdateNotice: ComponentWithChildren<UpdatenoticeProps> = ({
       borderRadius="lg"
       align={"center"}
       flexWrap="wrap"
-      css={`
+      css={css`
         container-type: inline-size;
       `}
     >
@@ -73,7 +74,7 @@ export const UpdateNotice: ComponentWithChildren<UpdatenoticeProps> = ({
       </Badge>
       <Text
         order={{ base: 3, md: 2 }}
-        css={`
+        css={css`
           order: 3 !important;
           @container (min-width: 48em) {
             order: 2 !important;
@@ -110,7 +111,7 @@ export const UpdateNotice: ComponentWithChildren<UpdatenoticeProps> = ({
           order={{ base: 2, md: 3 }}
           gap={2}
           align="center"
-          css={`
+          css={css`
             order: 2 !important;
             @container (min-width: 48em) {
               order: 3 !important;


### PR DESCRIPTION
PR fixes the below-shown error thrown by [emotion](https://github.com/emotion-js/emotion) in dev when clicking on the "Claim conditions" tab as shown below:

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/22043396/208627022-6ab98c2b-4818-4939-b111-23c07d9e5ae1.png">

