### PR TITLE
SDK page: Fix icon positions in ProductCard

### DIFF
--- a/components/product-pages/common/ProductCard.tsx
+++ b/components/product-pages/common/ProductCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
 import NextImage, { StaticImageData } from "next/image";
 import { Heading } from "tw-components";
 import { ComponentWithChildren } from "types/component-with-children";
@@ -33,9 +33,16 @@ export const ProductCard: ComponentWithChildren<ProductCardProps> = ({
       <Heading size="title.sm" mt="32px">
         {title}
       </Heading>
-      <Box fontSize="body.lg" mt="16px" color="paragraph" lineHeight={1.6}>
+      <Flex
+        direction={"column"}
+        fontSize="body.lg"
+        mt="16px"
+        color="paragraph"
+        lineHeight={1.6}
+        h="100%"
+      >
         {children}
-      </Box>
+      </Flex>
     </Flex>
   );
 };

--- a/pages/sdk.tsx
+++ b/pages/sdk.tsx
@@ -63,7 +63,8 @@ const Web3SDK: ThirdwebNextPage = () => {
             Use SDKs in programming languages that you are most comfortable
             with.
             <Flex
-              h="full"
+              mt={"auto"}
+              pt={8}
               justifyContent="flex-end"
               alignItems="flex-end"
               gap={3}


### PR DESCRIPTION
## The Problem

* icons in ProductCard the `/sdk` page are not properly positioned in Mobile View
<img width="370" alt="image" src="https://user-images.githubusercontent.com/22043396/208927818-499925a3-7380-4006-ac62-8a3ce31840a3.png">


* Their position on Desktop also gets distorted when content is increased 

<img width="1257" alt="image" src="https://user-images.githubusercontent.com/22043396/208928014-74acf975-4497-4d36-bba3-63534b159706.png">


<br />

## The Solution

PR Fixes above mentioned two issues as shown below:

<img width="381" alt="image" src="https://user-images.githubusercontent.com/22043396/208928223-a17976c6-7772-45a4-b02f-43123a81066e.png">

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/22043396/208928307-1e5b9898-a237-4a2d-8921-ece8354b4d53.png">
