### PR TITLE
Fix Logo Link in AppShell when wallet is not connected

### DIFF
--- a/components/layout/app-shell/index.tsx
+++ b/components/layout/app-shell/index.tsx
@@ -50,8 +50,6 @@ export const AppShell: ComponentWithChildren<AppShellProps> = ({
   noSEOOverride,
 }) => {
   const { pathname } = useRouter();
-  const address = useAddress();
-  const publicKey = useWallet().publicKey?.toBase58();
 
   const isCustomContractLayout = layout === "custom-contract";
   return (
@@ -96,7 +94,7 @@ export const AppShell: ComponentWithChildren<AppShellProps> = ({
             as="header"
             alignItems="center"
           >
-            <Link href={address || publicKey ? "/dashboard" : "/explore"}>
+            <Link href="/dashboard">
               <Logo />
             </Link>
             <Flex align="center" gap={2} marginLeft="auto">


### PR DESCRIPTION
Issue was that Logo in Dashboard points to /explore when the wallet is not connected
PR makes it so that Logo always points to /dashboard