### PR TITLE
/contracts/deploy page: Use the same icon for extensions used in dashboard

### DIFF
--- a/pages/contracts/deploy/[contractId].tsx
+++ b/pages/contracts/deploy/[contractId].tsx
@@ -23,7 +23,8 @@ import { useSingleQueryParam } from "hooks/useQueryParam";
 import { useRouter } from "next/router";
 import { PageId } from "page-id";
 import { useEffect, useRef } from "react";
-import { FiArrowLeft, FiCheckCircle, FiExternalLink } from "react-icons/fi";
+import { FiArrowLeft, FiExternalLink } from "react-icons/fi";
+import { VscExtensions } from "react-icons/vsc";
 import { Card, Heading, LinkButton, Text, TrackedLink } from "tw-components";
 import { pushToPreviousRoute } from "utils/pushToPreviousRoute";
 import { ThirdwebNextPage } from "utils/types";
@@ -165,7 +166,7 @@ const EnabledFeature: React.FC<EnabledFeatureProps> = ({ feature }) => {
     >
       <Flex gap={2} align="center" justify="space-between">
         <Flex gap={2} align="center">
-          <Icon boxSize={4} color="green.500" as={FiCheckCircle} />
+          <Icon boxSize={4} color="green.500" as={VscExtensions} />
           <LinkOverlay
             href={`https://portal.thirdweb.com/contracts/${feature.docLinks.contracts}`}
             isExternal


### PR DESCRIPTION
`/contracts/deploy` page is using a different icon for extensions compared to `/dashboard`

<img width="1215" alt="image" src="https://user-images.githubusercontent.com/22043396/210317024-e7ec0238-cb08-4cb6-b1eb-ea115a537924.png">

<img width="800" alt="image" src="https://user-images.githubusercontent.com/22043396/210317040-f34c9b8f-92cb-42e9-9114-a9c63723e7c2.png">


This PR Fixes that and makes the icon for extensions the same everywhere

<img width="1177" alt="image" src="https://user-images.githubusercontent.com/22043396/210317122-801be764-f310-4ce0-b000-b3e7311d1e5c.png">
