### PR TITLE
SettingsRoyalties: Mark Percentage dirty when value is changed

### DIFF
--- a/contract-ui/tabs/settings/components/platform-fees.tsx
+++ b/contract-ui/tabs/settings/components/platform-fees.tsx
@@ -125,6 +125,7 @@ export const SettingsPlatformFees = <
                 value={watch("platform_fee_basis_points")}
                 onChange={(value) =>
                   setValue("platform_fee_basis_points", value, {
+                    shouldDirty: true,
                     shouldTouch: true,
                   })
                 }

--- a/contract-ui/tabs/settings/components/royalties.tsx
+++ b/contract-ui/tabs/settings/components/royalties.tsx
@@ -123,6 +123,7 @@ export const SettingsRoyalties = <
                 value={watch("seller_fee_basis_points")}
                 onChange={(value) =>
                   setValue("seller_fee_basis_points", value, {
+                    shouldDirty: true,
                     shouldTouch: true,
                   })
                 }


### PR DESCRIPTION
## Bugs

https://user-images.githubusercontent.com/22043396/212348189-690514ca-739f-401f-9847-308f73a3e7a2.mov

* "Update Royalties Settings" button stays disabled even when the Royalty percentage input is updated
* "Update Platform Fee Settings" button stays disabled even when the Royalty percentage input is updated


## After the Fix


https://user-images.githubusercontent.com/22043396/212348670-16ca1d61-9b78-4597-90c8-63e1308db319.mov


