### PR TITLE
ClaimCondition Form: Disable snapshot edit button when form is disabled

### DIFF
--- a/contract-ui/tabs/claim-conditions/components/claim-conditions-form/Inputs/ClaimerSelection.tsx
+++ b/contract-ui/tabs/claim-conditions/components/claim-conditions-form/Inputs/ClaimerSelection.tsx
@@ -48,6 +48,8 @@ export const ClaimerSelection = () => {
 
   let helperText: React.ReactNode;
 
+  const disabledSnapshotButton = isAdmin && formDisabled;
+
   if (isClaimPhaseV1) {
     helperText = (
       <>
@@ -121,7 +123,7 @@ export const ClaimerSelection = () => {
             {/* disable the "Edit" button when form is disabled, but not when it's a "See" button */}
             <Button
               colorScheme="purple"
-              isDisabled={isAdmin && formDisabled}
+              isDisabled={disabledSnapshotButton}
               borderRadius="md"
               onClick={() => setOpenIndex(phaseIndex)}
               rightIcon={<Icon as={FiUpload} />}
@@ -134,6 +136,7 @@ export const ClaimerSelection = () => {
               direction="row"
               align="center"
               justify="center"
+              opacity={disabledSnapshotButton ? 0.5 : 1}
               color={field.snapshot?.length === 0 ? "red.400" : "green.400"}
               _light={{
                 color: field.snapshot?.length === 0 ? "red.500" : "green.500",

--- a/contract-ui/tabs/claim-conditions/components/claim-conditions-form/Inputs/ClaimerSelection.tsx
+++ b/contract-ui/tabs/claim-conditions/components/claim-conditions-form/Inputs/ClaimerSelection.tsx
@@ -13,7 +13,7 @@ import { Button, Text } from "tw-components";
  */
 export const ClaimerSelection = () => {
   const {
-    formDisabled: disabled,
+    formDisabled,
     form,
     phaseIndex,
     field,
@@ -84,7 +84,7 @@ export const ClaimerSelection = () => {
 
   return (
     <CustomFormControl
-      disabled={disabled}
+      disabled={formDisabled}
       label={`Who can claim ${isErc20 ? "tokens" : "NFTs"} during this phase?`}
       error={
         form.getFieldState(`phases.${phaseIndex}.snapshot`, form.formState)
@@ -95,7 +95,7 @@ export const ClaimerSelection = () => {
       <Flex direction={{ base: "column", md: "row" }} gap={4}>
         {/* Select Wallet Eligibility */}
         <Select
-          isDisabled={disabled}
+          isDisabled={formDisabled}
           w={{ base: "100%", md: "50%" }}
           value={dropType}
           onChange={handleClaimerChange}
@@ -118,8 +118,10 @@ export const ClaimerSelection = () => {
             align="center"
             gap={1.5}
           >
+            {/* disable the "Edit" button when form is disabled, but not when it's a "See" button */}
             <Button
               colorScheme="purple"
+              isDisabled={isAdmin && formDisabled}
               borderRadius="md"
               onClick={() => setOpenIndex(phaseIndex)}
               rightIcon={<Icon as={FiUpload} />}


### PR DESCRIPTION
### Current Behavior

* "See Snapshot button" is always enabled for non-admin user
* "Edit Snapshot button" is always enabled for admin user

https://user-images.githubusercontent.com/22043396/212715976-e51569f5-6253-4145-8c81-a73595af7e39.mov

### New Behavior

* "See Snapshot button" is always enabled for non-admin user
* "Edit Snapshot button" is always disabled when form data is being fetched for the admin user

https://user-images.githubusercontent.com/22043396/212717221-1baf1997-75f8-4330-89bf-702b85d93585.mov


