### PR TITLE
Metadesc/header/other small changes

### DIFF
--- a/pages/faucet/solana.tsx
+++ b/pages/faucet/solana.tsx
@@ -17,7 +17,7 @@ const SolanaFaucet: ThirdwebNextPage = () => {
     <>
       <NextSeo
         title="Solana (SOL) Faucet | thirdweb"
-        description="Get Solana devnet tokens for free—using our fast and reliable Solana Faucet for blockchain developers building web3 apps. Powered by thirdweb."
+        description="Get Solana (SOL) devnet tokens for free—using thirdweb's fast and reliable Solana Faucet for blockchain developers to build web3 apps."
         openGraph={{
           title:
             "Get Solana devnet tokens for free—using our fast and reliable Solana Faucet for blockchain developers building web3 apps. Powered by thirdweb.",
@@ -31,9 +31,9 @@ const SolanaFaucet: ThirdwebNextPage = () => {
         mx="auto"
         px={{ base: 0, md: 4 }}
       >
-        <Heading as="h1">Solana Faucet</Heading>
+        <Heading as="h1">Solana (SOL) Faucet</Heading>
         <Heading fontSize="20px" my="4" as="h2">
-          Get Solana devnet tokens for free to build your blockchain app.
+          Get Solana (SOL) devnet tokens for free to build your blockchain app.
         </Heading>
         {!transactionLink ? (
           <FormComponent


### PR DESCRIPTION
I see that our metatitle for this is "Solana (SOL) Faucet | thirdweb" - it used to show up like this on Google, but it seems to be showing as "Solana Faucet" now for some reason. (tried on different browsers, incognito, etc.):

<img width="613" alt="Screen Shot 2023-01-23 at 4 37 26 PM" src="https://user-images.githubusercontent.com/114959779/214155523-b35f091a-07d0-4fbc-a8e3-e83f5e4222bf.png">

Because of this, we're missing out on a lot of traffic that goes to "sol faucet" rather than "solana faucet" - we rank #4 for "solana faucet" but not at all for "sol faucet" & could easily rank in the top 5 for sol faucet as well!

Generally seeing discrepancies across Dashboard pages between what shows up on Google, what it shows up as when shared (og:title), and what shows up when on-page. @jnsdls hope you feel better throughout the week - lmk if you'll be able to make it to our SEO biweekly or if ya wanna push!