### PR TITLE
Fix code snippet not visible on light mode

### DIFF
--- a/tw-components/code-block.tsx
+++ b/tw-components/code-block.tsx
@@ -115,7 +115,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({
               }
             />
           )}
-          <Box as="span" display="block" my={1} color="white">
+          <Box as="span" display="block" my={1} color="heading">
             {tokens.map((line, i) => (
               // eslint-disable-next-line react/jsx-key
               <Box {...getLineProps({ line, key: i })}>


### PR DESCRIPTION

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/22043396/215618869-7694bb78-6f27-4198-93e7-c33a4606051a.png">
