### PR TITLE
Fix overflow in markdown renderer caused by inline code

### DIFF
--- a/components/contract-components/released-contract/markdown-renderer.tsx
+++ b/components/contract-components/released-contract/markdown-renderer.tsx
@@ -129,6 +129,7 @@ export const MarkdownRenderer: React.FC<
           return (
             <Text
               as="code"
+              whiteSpace="break-spaces"
               px={1}
               py={0.5}
               bg="blackAlpha.100"


### PR DESCRIPTION
Fixes this issue: 

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/22043396/216551519-39b7d9f6-c73c-4fdf-998a-dc675050ed89.png">

https://thirdweb.com/thirdweb.eth/TokenStake