### PR TITLE
Fix invalid route with one segment showing spinner indefinitely

### DIFF
--- a/pages/[profileAddress]/index.tsx
+++ b/pages/[profileAddress]/index.tsx
@@ -264,9 +264,21 @@ export const getStaticProps: GetStaticProps<UserPageProps> = async (ctx) => {
     };
   }
 
-  const { address, ensName } = await queryClient.fetchQuery(
-    ensQuery(profileAddress),
-  );
+  let address: string | null, ensName: string | null;
+  try {
+    const info = await queryClient.fetchQuery(ensQuery(profileAddress));
+    address = info.address;
+    ensName = info.ensName;
+  } catch (e) {
+    // if profileAddress is not a valid address, ensQuery throws
+    // in that case - redirect to 404
+    return {
+      redirect: {
+        destination: "/404",
+        permanent: false,
+      },
+    };
+  }
 
   if (!address) {
     return {


### PR DESCRIPTION
example: https://thirdweb.com/foo shows spinner forever instead of redirecting to a different page

valid routes with one segment: 
https://thirdweb.com/jns.eth
https://thirdweb.com/0x1F846F6DAE38E1C88D71EAA191760B15f38B7A37


I'm redirecting to 404 now, but we can also redirect to /explore or something ..