### PR TITLE
Fix Solana NFT table crash when token Id is number

### DIFF
--- a/program-ui/nft/components/table.tsx
+++ b/program-ui/nft/components/table.tsx
@@ -47,9 +47,9 @@ export const NFTGetAllTable: React.FC<{
           }
           return row.metadata.id;
         },
-        Cell: (cell: CellProps<NFT, string>) => (
+        Cell: (cell: CellProps<NFT, string | number>) => (
           <Text size="body.md" fontFamily="mono">
-            {shortenIfAddress(cell.value)}
+            {shortenIfAddress(`${cell.value}`)}
           </Text>
         ),
       },


### PR DESCRIPTION
This Error noticed on https://thirdweb.com/solana/D6FiWCSgnC26RP1AtZudChVfW3KfWasehkn1kCyip7V

![image](https://user-images.githubusercontent.com/22043396/218994719-4a7f1478-840d-461c-b66b-12869b779a02.png)
