### PR TITLE
use "publish" instead of "release"

### DIFF
--- a/pages/publish.tsx
+++ b/pages/publish.tsx
@@ -13,15 +13,15 @@ const TRACKING_CATEGORY = "publish";
 
 const PUBLISH_GUIDES = [
   {
-    title: "Introducing thirdweb Release",
+    title: "Introducing thirdweb Publish",
     image:
-      "https://blog.thirdweb.com/content/images/size/w2000/2022/09/Blog-thumbnail_tw-release.png",
+      "https://blog.thirdweb.com/content/images/size/w2000/2023/02/publish-ogimage.png",
     link: "https://blog.thirdweb.com/thirdweb-release/",
   },
   {
-    title: "Register Your Contracts Using Release",
+    title: "Share your smart contracts with thirdweb Publish",
     image:
-      "https://blog.thirdweb.com/content/images/size/w2000/2022/09/register-your-smart-contracts-using-thirdweb-release.png",
+      "https://blog.thirdweb.com/content/images/size/w2000/2023/03/Publish-your-smart-contracts-to-all-of-web3-2.png",
     link: "https://blog.thirdweb.com/guides/register-your-contract-using-thirdweb-release/",
   },
 ];


### PR DESCRIPTION
Updated the guides section to use Publish instead of Release

Before:

<img width="1208" alt="image" src="https://user-images.githubusercontent.com/11805367/223944279-0de6e6c2-a484-486a-8d79-45117e6dca9e.png">

After:

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/11805367/223944374-5738bd9e-04e8-454c-9021-4bcce216c231.png">
