### PR TITLE
Fix broken pages on non-default chains

### DIFF
--- a/components/app-layouts/providers.tsx
+++ b/components/app-layouts/providers.tsx
@@ -4,6 +4,7 @@ import {
   useEVMContractInfo,
 } from "@3rdweb-sdk/react/hooks/useActiveChainId";
 import { useQueryClient } from "@tanstack/react-query";
+import { Ethereum } from "@thirdweb-dev/chains";
 import {
   ThirdwebProvider,
   coinbaseWallet,
@@ -54,7 +55,7 @@ export const DashboardThirdwebProvider: ComponentWithChildren<
         isDarkMode: false,
         url: "https://thirdweb.com",
       }}
-      activeChain={chain?.chainId}
+      activeChain={chain === null ? undefined : chain}
       supportedChains={supportedChains}
       sdkOptions={{
         gasSettings: { maxPriceInGwei: 650 },


### PR DESCRIPTION
Root cause 
* passing chainId as activeChain which is not one of supportedChains or defaultChains 
* this was fine earlier - but now SDK throws an error if given chainId is not one of supportedChains in react-core
* this was done - because that's invalid - react-core would silently fail to resolve the chainId to chain object and use Ethereum
* now we throw an error to let the users of SDK know that that's invalid
* so need to pass entire chain object 