### PR TITLE
fix: remove sentry + github api deps

### DIFF
--- a/pages/open-source.tsx
+++ b/pages/open-source.tsx
@@ -247,43 +247,47 @@ const OSS: ThirdwebNextPage = ({ contributors }: PageProps) => {
               </Flex>
             </Flex>
           </HomepageSection>
-          <HomepageSection pb={32}>
-            <Heading size="display.sm" mb={12}>
-              Top Community Contributors
-            </Heading>
-            <SimpleGrid
-              columns={{ base: 2, md: 4 }}
-              gap={8}
-              justifyContent="space-evenly"
-            >
-              {contributors.slice(0, 12).map((contributor) => (
-                <Flex
-                  key={contributor.login}
-                  flexDir="row"
-                  gap={2}
-                  alignItems="center"
-                >
-                  <MaskedAvatar src={contributor.avatar_url} />
-                  <Flex key={contributor.login} flexDir="column" gap={1}>
-                    <TrackedLink
-                      href={`https://github.com/${contributor.login}`}
-                      isExternal
-                      category="team"
-                      label={contributor.login}
-                    >
-                      <Heading size="title.sm">@{contributor.login}</Heading>
-                    </TrackedLink>
-                    <Text size="label.md" color="gray.500">
-                      {contributor.contributions}{" "}
-                      {contributor.contributions === 1
-                        ? "contribution"
-                        : "contributions"}
-                    </Text>
+
+          {contributors.length > 0 && (
+            <HomepageSection pb={32}>
+              <Heading size="display.sm" mb={12}>
+                Top Community Contributors
+              </Heading>
+              <SimpleGrid
+                columns={{ base: 2, md: 4 }}
+                gap={8}
+                justifyContent="space-evenly"
+              >
+                {contributors.slice(0, 12).map((contributor) => (
+                  <Flex
+                    key={contributor.login}
+                    flexDir="row"
+                    gap={2}
+                    alignItems="center"
+                  >
+                    <MaskedAvatar src={contributor.avatar_url} />
+                    <Flex key={contributor.login} flexDir="column" gap={1}>
+                      <TrackedLink
+                        href={`https://github.com/${contributor.login}`}
+                        isExternal
+                        category="team"
+                        label={contributor.login}
+                      >
+                        <Heading size="title.sm">@{contributor.login}</Heading>
+                      </TrackedLink>
+                      <Text size="label.md" color="gray.500">
+                        {contributor.contributions}{" "}
+                        {contributor.contributions === 1
+                          ? "contribution"
+                          : "contributions"}
+                      </Text>
+                    </Flex>
                   </Flex>
-                </Flex>
-              ))}
-            </SimpleGrid>
-          </HomepageSection>
+                ))}
+              </SimpleGrid>
+            </HomepageSection>
+          )}
+
           <HomepageSection pb={32}>
             <Heading size="display.sm" mb={12}>
               Repositories
@@ -312,6 +316,12 @@ export default OSS;
 export const getStaticProps: GetStaticProps = async () => {
   // Array of accounts to be tracked
   const accounts = ["thirdweb-dev", "thirdweb-example"];
+
+  if (!process.env.GITHUB_API_TOKEN) {
+    return {
+      props: { contributors: [] },
+    };
+  }
 
   const authHeader = {
     headers: {

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -7,9 +7,7 @@ import * as Sentry from "@sentry/nextjs";
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
-  dsn:
-    SENTRY_DSN ||
-    "https://8813f5d93c8c4aa89eda86816f0b1bbf@o1378374.ingest.sentry.io/6690186",
+  dsn: SENTRY_DSN,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0,
   // ...

--- a/sentry.edge.config.js
+++ b/sentry.edge.config.js
@@ -7,9 +7,7 @@ import * as Sentry from "@sentry/nextjs";
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
-  dsn:
-    SENTRY_DSN ||
-    "https://8813f5d93c8c4aa89eda86816f0b1bbf@o1378374.ingest.sentry.io/6690186",
+  dsn: SENTRY_DSN,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0,
   // ...

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -7,9 +7,7 @@ import * as Sentry from "@sentry/nextjs";
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
-  dsn:
-    SENTRY_DSN ||
-    "https://8813f5d93c8c4aa89eda86816f0b1bbf@o1378374.ingest.sentry.io/6690186",
+  dsn: SENTRY_DSN,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0,
   // ...


### PR DESCRIPTION
- allows dashboard to be deployed w/o SENTRY_DSN & GITHUB_API_TOKEN
- if not set, contributors won't show up nor errors reported