### PR TITLE
Turn off focus trap on PrivacyNotice modal

### DIFF
--- a/components/notices/PrivacyNotice.tsx
+++ b/components/notices/PrivacyNotice.tsx
@@ -67,6 +67,7 @@ export const PrivacyNotice: React.FC = () => {
       isCentered
       isOpen
       onClose={() => undefined}
+      trapFocus={false}
     >
       <ModalOverlay />
       <ModalContent>


### PR DESCRIPTION
why? - https://linear.app/thirdweb/issue/PLAT-985#comment-d0cf3796

PrivacyNotice Modal's focus trapping does not allow selecting network in Safe wallet 