### PR TITLE
Fix error on /sources for chain with empty explorers array

### DIFF
--- a/contract-ui/tabs/sources/page.tsx
+++ b/contract-ui/tabs/sources/page.tsx
@@ -129,12 +129,12 @@ const VerifyContractModal: React.FC<ConnectorModalProps> = ({
 
   const blockExplorerName =
     getBlockExplorerName(chainId) ||
-    (chainInfo && chainInfo.explorers?.[0].name) ||
+    (chainInfo && chainInfo.explorers?.[0]?.name) ||
     "";
 
   const blockExplorerUrl =
     getBlockExplorerUrl(chainId, contractAddress) ||
-    (chainInfo && chainInfo.explorers?.[0].url) ||
+    (chainInfo && chainInfo.explorers?.[0]?.url) ||
     "";
 
   return (


### PR DESCRIPTION
I'm currently fixing this issue only but 
we should enable `"noUncheckedIndexedAccess": true` and fix all the issues like this 

https://linear.app/thirdweb/issue/FTD-1877/fix-unchecked-indexes