### PR TITLE
Disable font ligatures

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -176,6 +176,9 @@ const ConsoleApp = memo(function ConsoleApp({
             vertical-align: -0.1em;
             display: inline;
           }
+          body {
+            font-variant-ligatures: none !important;
+          }
         `}
       />
       <DefaultSeo


### PR DESCRIPTION
Disable font ligature to prevent showing of 'x' in the account address in two different ways as shown below

https://rsms.me/inter/ 

![image](https://github.com/thirdweb-dev/dashboard/assets/22043396/6fc964db-9bbb-4e05-aad2-514de14e7c0d)
