### PR TITLE
Fix OG image not showing contract with name <=3 characters

### DIFF
--- a/pages/api/og/contract.tsx
+++ b/pages/api/og/contract.tsx
@@ -63,11 +63,13 @@ const OgBrandIcon: React.FC = () => (
 const MAX_LENGTH = 50;
 
 function textShortener(text: string) {
-  let words = [];
+  const words = [];
   let currentLength = 0;
   let shortened = false;
 
   const allWords = text.split(" ");
+
+  // no shorting for one word
   if (allWords.length === 1) {
     return text;
   }
@@ -81,9 +83,7 @@ function textShortener(text: string) {
     words.push(word);
     currentLength += word.length + 1;
   }
-  if (words[words.length - 1].length < 4) {
-    words = words.slice(0, -1);
-  }
+
   if (words[words.length - 1]?.endsWith(".")) {
     return words.join(" ");
   }

--- a/pages/api/og/contract.tsx
+++ b/pages/api/og/contract.tsx
@@ -66,7 +66,13 @@ function textShortener(text: string) {
   let words = [];
   let currentLength = 0;
   let shortened = false;
-  for (const word of text.split(" ")) {
+
+  const allWords = text.split(" ");
+  if (allWords.length === 1) {
+    return text;
+  }
+
+  for (const word of allWords) {
     // +1 for the space
     if (currentLength + word.length + 1 > MAX_LENGTH) {
       shortened = true;


### PR DESCRIPTION
Fixes https://linear.app/thirdweb/issue/FTD-1950/og-image-for-contract-doesnt-pull-contract-name-correctly