### PR TITLE
Fix issue #1391

### DIFF
--- a/contract-ui/tabs/nfts/components/table.tsx
+++ b/contract-ui/tabs/nfts/components/table.tsx
@@ -139,7 +139,7 @@ export const NFTGetAllTable: React.FC<ContractOverviewNFTGetAllProps> = ({
       },
       manualPagination: true,
       pageCount: Math.max(
-        Math.ceil(safeTotalCount.div(queryParams.count || 1).toNumber()),
+        Math.ceil(safeTotalCount.toNumber() / (queryParams.count || 1)),
         1,
       ),
     },


### PR DESCRIPTION
For 50 items per page:
Old code:
```
Math.ceil(safeTotalCount.div(50).toNumber()); // 101 -> 2 pages (incorrect)
```

New code:
```
Math.ceil(safeTotalCount.toNumber() / 50); // 101 items -> 3 pages (correct)
```

You can test with this collection here (it has 101 nfts): https://thirdweb.com/avalanche-fuji/0xAD4A13F5dabFf3A0a2C7d9F6eB8670753a4C6159/nfts