### PR TITLE
tweak: add space to text

### DIFF
--- a/components/homepage/sections/ValuesSection.tsx
+++ b/components/homepage/sections/ValuesSection.tsx
@@ -13,7 +13,7 @@ const features: FeatureCardProps[] = [
     title: "Open Source.",
     description: (
       <>
-        The code for our tools, contracts, SDKs, dashboard, and UI components is
+        The code for our tools, contracts, SDKs, dashboard, and UI components is{" "}
         <TrackedLink
           color="white"
           fontWeight="500"


### PR DESCRIPTION
Add space to the text from the value section of the homepage.
<img width="299" alt="image" src="https://github.com/thirdweb-dev/dashboard/assets/15052701/c7731344-94f7-4de9-9d30-076284ae7d84">
