### PR TITLE
Connect options for additional wallets

### DIFF
--- a/components/app-layouts/app.tsx
+++ b/components/app-layouts/app.tsx
@@ -27,6 +27,7 @@ import { PrivacyNotice } from "components/notices/PrivacyNotice";
 import { AllChainsProvider } from "contexts/all-chains";
 import { ChainsProvider } from "contexts/configured-chains";
 import { ErrorProvider } from "contexts/error-handler";
+import EvmWalletProvider from "contexts/evm-wallets";
 import { isSanctionedAddress } from "data/eth-sanctioned-addresses";
 import { useAddRecentlyUsedChainId } from "hooks/chains/recentlyUsedChains";
 import {
@@ -133,14 +134,16 @@ export const AppLayout: ComponentWithChildren<AppLayoutProps> = (props) => {
             <AllChainsProvider>
               <ChainsProvider>
                 <EVMContractInfoProvider value={props.contractInfo}>
-                  <DashboardThirdwebProvider>
-                    <SanctionedAddressesChecker>
-                      <PHIdentifier />
-                      <PrivacyNotice />
-                      <AppShell {...props} />
-                      <ConfigModal />
-                    </SanctionedAddressesChecker>
-                  </DashboardThirdwebProvider>
+                  <EvmWalletProvider>
+                    <DashboardThirdwebProvider>
+                      <SanctionedAddressesChecker>
+                        <PHIdentifier />
+                        <PrivacyNotice />
+                        <AppShell {...props} />
+                        <ConfigModal />
+                      </SanctionedAddressesChecker>
+                    </DashboardThirdwebProvider>
+                  </EvmWalletProvider>
                 </EVMContractInfoProvider>
               </ChainsProvider>
             </AllChainsProvider>

--- a/components/app-layouts/providers.tsx
+++ b/components/app-layouts/providers.tsx
@@ -6,18 +6,10 @@ import {
 } from "@3rdweb-sdk/react/hooks/useActiveChainId";
 import { fetchAuthToken } from "@3rdweb-sdk/react/hooks/useApi";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  ThirdwebProvider,
-  coinbaseWallet,
-  localWallet,
-  metamaskWallet,
-  paperWallet,
-  safeWallet,
-  useUser,
-  walletConnect,
-} from "@thirdweb-dev/react";
+import { ThirdwebProvider, useUser } from "@thirdweb-dev/react";
 import { GLOBAL_AUTH_TOKEN_KEY } from "constants/app";
 import { DASHBOARD_THIRDWEB_CLIENT_ID } from "constants/rpc";
+import { useEvmWallets } from "contexts/evm-wallets";
 import { useSupportedChains } from "hooks/chains/configureChains";
 import { useNativeColorMode } from "hooks/useNativeColorMode";
 import { getDashboardChainRpc } from "lib/rpc";
@@ -29,25 +21,6 @@ export interface DashboardThirdwebProviderProps {
   contractInfo?: EVMContractInfo;
 }
 
-const personalWallets = [
-  metamaskWallet(),
-  coinbaseWallet(),
-  walletConnect({
-    qrModalOptions: {
-      themeVariables: {
-        "--wcm-z-index": "10000",
-      },
-    },
-  }),
-  paperWallet({
-    paperClientId: "9a2f6238-c441-4bf4-895f-d13c2faf2ddb",
-    advancedOptions: {
-      recoveryShareManagement: "AWS_MANAGED",
-    },
-  }),
-  localWallet(),
-];
-
 export const DashboardThirdwebProvider: ComponentWithChildren<
   DashboardThirdwebProviderProps
 > = ({ children }) => {
@@ -56,6 +29,7 @@ export const DashboardThirdwebProvider: ComponentWithChildren<
   const supportedChains = useSupportedChains();
   const contractInfo = useEVMContractInfo();
   const chain = contractInfo?.chain;
+  const { supportedWallets } = useEvmWallets();
   const readonlySettings = useMemo(() => {
     if (!chain) {
       return undefined;
@@ -86,12 +60,7 @@ export const DashboardThirdwebProvider: ComponentWithChildren<
         readonlySettings,
       }}
       clientId={DASHBOARD_THIRDWEB_CLIENT_ID}
-      supportedWallets={[
-        ...personalWallets,
-        safeWallet({
-          personalWallets,
-        }),
-      ]}
+      supportedWallets={supportedWallets}
       storageInterface={StorageSingleton}
       authConfig={{
         domain: THIRDWEB_DOMAIN,

--- a/contexts/evm-wallets.tsx
+++ b/contexts/evm-wallets.tsx
@@ -1,0 +1,157 @@
+import {
+  WalletConfig,
+  coinbaseWallet,
+  localWallet,
+  metamaskWallet,
+  paperWallet,
+  rainbowWallet,
+  safeWallet,
+  trustWallet,
+  walletConnect,
+  zerionWallet,
+} from "@thirdweb-dev/react";
+import {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+const METAMASK_WALLET = metamaskWallet();
+const COINBASE_WALLET = coinbaseWallet();
+const TRUST_WALLET = trustWallet();
+const ZERION_WALLET = zerionWallet();
+const RAINBOW_WALLET = rainbowWallet();
+
+const WALLET_CONNECT = walletConnect({
+  qrModalOptions: {
+    themeVariables: {
+      "--wcm-z-index": "10000",
+    },
+  },
+});
+
+const PAPER_WALLET = paperWallet({
+  paperClientId: "9a2f6238-c441-4bf4-895f-d13c2faf2ddb",
+  advancedOptions: {
+    recoveryShareManagement: "AWS_MANAGED",
+  },
+});
+
+const LOCAL_WALLET = localWallet();
+
+const PERSONAL_EVM_WALLETS = [
+  METAMASK_WALLET,
+  COINBASE_WALLET,
+  WALLET_CONNECT,
+  PAPER_WALLET,
+  LOCAL_WALLET,
+];
+
+const SAFE_WALLET = safeWallet({
+  personalWallets: PERSONAL_EVM_WALLETS,
+});
+
+export const DEFAULT_EVM_WALLETS = [...PERSONAL_EVM_WALLETS, SAFE_WALLET];
+
+type EvmWalletsContext = {
+  supportedWallets: WalletConfig<any>[];
+  additionalWalletOptions: AdditionalWalletOptions;
+  setAdditionalWalletOptions: Dispatch<SetStateAction<AdditionalWalletOptions>>;
+};
+
+const DEFAULT_WALLET_OPTIONS = {
+  trustWallet: false,
+  zerionWallet: false,
+  rainbowWallet: false,
+};
+const Context = createContext<EvmWalletsContext>({
+  supportedWallets: DEFAULT_EVM_WALLETS,
+  additionalWalletOptions: DEFAULT_WALLET_OPTIONS,
+  setAdditionalWalletOptions: () => {},
+});
+
+const ADDITIONAL_WALLET_SLUGS = [
+  "trustWallet",
+  "zerionWallet",
+  "rainbowWallet",
+] as const;
+
+export type AdditionalWalletSlug = (typeof ADDITIONAL_WALLET_SLUGS)[number];
+
+type AdditionalWalletOptions = { [key in AdditionalWalletSlug]: boolean };
+
+export const ADDITIONAL_WALLETS: {
+  [key in AdditionalWalletSlug]: WalletConfig<any>;
+} = {
+  trustWallet: TRUST_WALLET,
+  zerionWallet: ZERION_WALLET,
+  rainbowWallet: RAINBOW_WALLET,
+};
+
+export const TW_EVM_WALLET_KEY = "tw-evm-wallet-toggle-options";
+
+export default function EvmWalletProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [additionalWalletOptions, setAdditionalWalletOptions] =
+    useState<AdditionalWalletOptions>(DEFAULT_WALLET_OPTIONS);
+
+  const getAdditionalWallets = (): WalletConfig<any>[] => {
+    const _wallets: WalletConfig<any>[] = [];
+    ADDITIONAL_WALLET_SLUGS.forEach((slug) => {
+      if (!additionalWalletOptions[slug]) return;
+      _wallets.push(ADDITIONAL_WALLETS[slug]);
+    });
+    return [...DEFAULT_EVM_WALLETS, ..._wallets];
+  };
+
+  const supportedWallets: WalletConfig<any>[] = getAdditionalWallets();
+
+  // Fetch config from localStorage
+  useEffect(() => {
+    try {
+      const data = localStorage.getItem(TW_EVM_WALLET_KEY);
+      const walletOptions = data
+        ? (JSON.parse(data) as AdditionalWalletOptions)
+        : null;
+      if (
+        !walletOptions ||
+        Array.isArray(walletOptions) ||
+        typeof walletOptions !== "object"
+      ) {
+        throw Error("Invalid data");
+      }
+      setAdditionalWalletOptions(walletOptions);
+    } catch (e) {
+      // if parsing error, clear dirty storage
+      localStorage.removeItem(TW_EVM_WALLET_KEY);
+    }
+  }, []);
+
+  return (
+    <Context.Provider
+      value={{
+        supportedWallets,
+        additionalWalletOptions,
+        setAdditionalWalletOptions,
+      }}
+    >
+      {children}
+    </Context.Provider>
+  );
+}
+
+export const useEvmWallets = () => {
+  const context = useContext(Context);
+  if (context === undefined) {
+    throw new Error("useEvmWallets must be used inside EvmWalletProvider");
+  }
+
+  return context;
+};

--- a/core-ui/sidebar/settings.tsx
+++ b/core-ui/sidebar/settings.tsx
@@ -2,11 +2,16 @@ import { SidebarNav } from "./nav";
 import { Route } from "./types";
 
 type SettingsSidebarProps = {
-  activePage: "apiKeys";
+  activePage: string;
 };
 
 const links: Route[] = [
   { path: "/dashboard/settings/api-keys", title: "API Keys", name: "apiKeys" },
+  {
+    path: "/dashboard/settings/wallet-options",
+    title: "Wallet Options",
+    name: "walletOptions",
+  },
 ];
 
 export const SettingsSidebar: React.FC<SettingsSidebarProps> = ({

--- a/page-id.ts
+++ b/page-id.ts
@@ -109,6 +109,9 @@ export enum PageId {
   // thirdweb.com/settings/api-keys
   SettingsApiKeys = "settings-api-keys",
 
+  // thirdweb.com/settings/wallet-options
+  SettingsWalletOptions = "settings-wallet-options",
+  
   // ---------------------------------------------------------------------------
   //  solutions pages
   // ---------------------------------------------------------------------------

--- a/pages/dashboard/settings/wallet-options.tsx
+++ b/pages/dashboard/settings/wallet-options.tsx
@@ -1,0 +1,135 @@
+import { Flex, SimpleGrid } from "@chakra-ui/react";
+import { AppLayout } from "components/app-layouts/app";
+import { ChainIcon } from "components/icons/ChainIcon";
+import {
+  ADDITIONAL_WALLETS,
+  AdditionalWalletSlug,
+  DEFAULT_EVM_WALLETS,
+  TW_EVM_WALLET_KEY,
+  useEvmWallets,
+} from "contexts/evm-wallets";
+import { SettingsSidebar } from "core-ui/sidebar/settings";
+import { PageId } from "page-id";
+import { Card, Heading, Text } from "tw-components";
+import { ThirdwebNextPage } from "utils/types";
+
+const SettingsWalletOptionsPage: ThirdwebNextPage = () => {
+  const { additionalWalletOptions, setAdditionalWalletOptions } =
+    useEvmWallets();
+
+  const toggleAdditionalWallet = (slug: AdditionalWalletSlug) => {
+    additionalWalletOptions[slug] = !additionalWalletOptions[slug];
+    setAdditionalWalletOptions({ ...additionalWalletOptions });
+    const value = JSON.stringify(additionalWalletOptions);
+    try {
+      localStorage.setItem(TW_EVM_WALLET_KEY, value);
+    } catch (e) {
+      // if storage limit exceed
+      // clear entire local storage and then try again
+      localStorage.clear();
+      localStorage.setItem(TW_EVM_WALLET_KEY, value);
+    }
+  };
+
+  return (
+    <>
+      <Flex flexDir="column" gap={8} mt={{ base: 2, md: 6 }}>
+        <Flex direction="column" gap={2}>
+          <Flex
+            justifyContent="space-between"
+            direction={{ base: "column", md: "row" }}
+            gap={4}
+          >
+            <Heading size="title.lg" as="h1">
+              Wallet Options
+            </Heading>
+          </Flex>
+          <Text>More options to connect to Thirdweb Dashboard</Text>
+        </Flex>
+        <Heading size="title.md" as="h2">
+          Default Wallets
+        </Heading>
+        <SimpleGrid columns={{ base: 1, md: 3 }} gap={4}>
+          {DEFAULT_EVM_WALLETS.map((wallet) => (
+            <Card
+              key={wallet.id}
+              as={Flex}
+              flexDir="column"
+              gap={3}
+              p={6}
+              position="relative"
+              cursor={"not-allowed"}
+              overflow="hidden"
+            >
+              <Flex justifyContent="space-between">
+                <Flex alignItems="center" gap={3}>
+                  <ChainIcon size={25} ipfsSrc={wallet.meta.iconURL} />
+
+                  <Heading size="subtitle.sm" as="h3" noOfLines={1}>
+                    {wallet.meta.name}
+                  </Heading>
+                </Flex>
+                <Text my={"auto"} color={"green.500"}>
+                  Enabled
+                </Text>
+              </Flex>
+            </Card>
+          ))}
+        </SimpleGrid>
+        <Heading size="title.md" as="h2">
+          Additional Wallets
+        </Heading>
+        <SimpleGrid columns={{ base: 1, md: 3 }} gap={4}>
+          {(Object.keys(ADDITIONAL_WALLETS) as AdditionalWalletSlug[]).map(
+            (slug) => {
+              const wallet = ADDITIONAL_WALLETS[slug];
+              const walletEnabled = additionalWalletOptions[slug];
+              return (
+                <Card
+                  key={wallet.id}
+                  onClick={() => toggleAdditionalWallet(slug)}
+                  as={Flex}
+                  flexDir="column"
+                  gap={3}
+                  p={6}
+                  _hover={{ borderColor: "blue.500" }}
+                  position="relative"
+                  cursor={"pointer"}
+                  overflow="hidden"
+                >
+                  <Flex justifyContent="space-between">
+                    <Flex alignItems="center" gap={3}>
+                      <ChainIcon size={25} ipfsSrc={wallet.meta.iconURL} />
+
+                      <Heading size="subtitle.sm" as="h3" noOfLines={1}>
+                        {wallet.meta.name}
+                      </Heading>
+                    </Flex>
+                    <Text
+                      my={"auto"}
+                      color={walletEnabled ? "green.500" : "gray.500"}
+                    >
+                      {walletEnabled ? "Enabled" : "Disabled"}
+                    </Text>
+                  </Flex>
+                </Card>
+              );
+            },
+          )}
+        </SimpleGrid>
+      </Flex>
+    </>
+  );
+};
+
+SettingsWalletOptionsPage.getLayout = (page, props) => (
+  <AppLayout {...props} hasSidebar={true}>
+    <SettingsSidebar activePage="walletOptions" />
+
+    {page}
+  </AppLayout>
+);
+
+SettingsWalletOptionsPage.pageId = PageId.SettingsWalletOptions;
+
+export default SettingsWalletOptionsPage;


### PR DESCRIPTION
I wanted to use the Dashboard with my Trust wallet because using WalletConnect was very buggy. Issue described here: https://discord.com/channels/834227967404146718/1132819174905888798

So I think the dashboard should have the feature to let users add more connect options.

![image](https://github.com/thirdweb-dev/dashboard/assets/26052673/2b005307-f395-46e7-81b2-51917b83b55b)
![image](https://github.com/thirdweb-dev/dashboard/assets/26052673/36d66547-df5c-447e-b877-80c60f784bae)
