### PR TITLE
Fix GuidesShowcase description alignment

### DIFF
--- a/components/product-pages/common/GuideShowcase.tsx
+++ b/components/product-pages/common/GuideShowcase.tsx
@@ -31,7 +31,7 @@ export const GuidesShowcase: React.FC<GuidesShowcaseProps> = ({
   return (
     <ProductSection>
       <Flex flexDir="column" py={16} align="center" gap={{ base: 6, lg: 8 }}>
-        <Flex flexDir="column" gap={2} justifyContent="start">
+        <Flex flexDir="column" gap={2} alignItems="center">
           <Heading
             as="h2"
             size="display.sm"


### PR DESCRIPTION
issues: 


<img width="460" alt="image" src="https://github.com/thirdweb-dev/dashboard/assets/22043396/1d1d30ac-bf13-449a-ad41-e0764ff82024">

<img width="434" alt="image" src="https://github.com/thirdweb-dev/dashboard/assets/22043396/e5abd850-d8d1-4a33-b74d-36613210a4eb">
