### PR TITLE
Fix Smart Wallet connection in ConnectWallet playground

### DIFF
--- a/components/wallets/ConnectWalletPlayground/PreviewThirdwebProvider.tsx
+++ b/components/wallets/ConnectWalletPlayground/PreviewThirdwebProvider.tsx
@@ -12,7 +12,6 @@ export function PreviewThirdwebProvider(props: {
 }) {
   return (
     <ThirdwebProvider
-      autoConnect={false}
       activeChain="mumbai"
       supportedWallets={
         props.supportedWallets.length > 0 ? props.supportedWallets : undefined


### PR DESCRIPTION
For some weird reason, setting autoConnect={false} on ThirdwebProvider inside ThirdwebProvider for the playground creates an issue with smart wallet - I'll need to debug this further and fix the root cause in SDK but for now this fixes the issue