### PR TITLE
Deprecate SignatureDrop

### DIFF
--- a/data/explore.ts
+++ b/data/explore.ts
@@ -44,7 +44,6 @@ const NFTS = {
     "unlock-protocol.eth/PublicLock",
     "thirdweb.eth/DropERC721",
     "thirdweb.eth/DropERC1155",
-    "thirdweb.eth/SignatureDrop",
     "thirdweb.eth/Multiwrap",
     "kronickatz.eth/ERC721NESDrop",
   ],
@@ -69,7 +68,6 @@ const DROPS = {
   contracts: [
     "thirdweb.eth/DropERC721",
     "thirdweb.eth/DropERC1155",
-    "thirdweb.eth/SignatureDrop",
     "thirdweb.eth/DropERC20",
   ],
 } as const;


### PR DESCRIPTION
Deprecating it because we often receive support questions for it, and it often doesn't meet the user's needs. Currently, it causes more confusion than it provides usefulness