### PR TITLE
Payments Bug Fix: Register Wrong Contract Type

### DIFF
--- a/@3rdweb-sdk/react/hooks/usePayments.ts
+++ b/@3rdweb-sdk/react/hooks/usePayments.ts
@@ -328,13 +328,21 @@ export function usePaymentsRegisterContract() {
         ? "THIRDWEB"
         : "CUSTOM_CONTRACT";
 
+      let displayName;
+      try {
+        const metadata = await contract.metadata.get();
+        displayName = metadata.name;
+      } catch (e) {
+        console.error(`Failed to get contract metadata`);
+      }
+
       const body: RegisterContractInput = {
         ...input,
         contractDefinition: contract.abi,
         contractAddress: input.contractAddress.toLowerCase(),
         chain: ChainIdToPaperChain[parseInt(input.chain)],
         contractType,
-        displayName: input.displayName,
+        displayName,
       };
 
       return fetchFromPaymentsAPI<RegisterContractInput>(

--- a/@3rdweb-sdk/react/hooks/usePayments.ts
+++ b/@3rdweb-sdk/react/hooks/usePayments.ts
@@ -323,12 +323,17 @@ export function usePaymentsRegisterContract() {
       const contract = await sdk.getContract(input.contractAddress);
       invariant(contract?.abi, "No contract ABI found");
 
+      const hasDetectedExtensions = hasPaymentsDetectedExtensions(contract);
+      const contractType = hasDetectedExtensions
+        ? "THIRDWEB"
+        : "CUSTOM_CONTRACT";
+
       const body: RegisterContractInput = {
         ...input,
         contractDefinition: contract.abi,
         contractAddress: input.contractAddress.toLowerCase(),
         chain: ChainIdToPaperChain[parseInt(input.chain)],
-        contractType: input.contractType || "THIRDWEB",
+        contractType,
         displayName: input.displayName,
       };
 

--- a/components/payments/enable-payments-button.tsx
+++ b/components/payments/enable-payments-button.tsx
@@ -4,7 +4,6 @@ import {
   usePaymentsRegisterContract,
 } from "@3rdweb-sdk/react/hooks/usePayments";
 import { Flex } from "@chakra-ui/react";
-import { useContract } from "@thirdweb-dev/react";
 import { useTrack } from "hooks/analytics/useTrack";
 import { useChainSlug } from "hooks/chains/chainSlug";
 import { useTxNotifications } from "hooks/useTxNotifications";
@@ -23,8 +22,6 @@ export const EnablePaymentsButton: React.FC<EnablePaymentsButtonProps> = ({
 }) => {
   const { mutate: registerContract, isLoading } = usePaymentsRegisterContract();
   const { data: paymentEnabledContracts } = usePaymentsEnabledContracts();
-  const { contract } = useContract(contractAddress);
-  const hasDetectedExtensions = hasPaymentsDetectedExtensions(contract);
 
   const contractIsEnabled = useMemo(() => {
     return paymentEnabledContracts?.some(
@@ -62,9 +59,6 @@ export const EnablePaymentsButton: React.FC<EnablePaymentsButtonProps> = ({
               {
                 chain: `${chainId}`,
                 contractAddress,
-                contractType: hasDetectedExtensions
-                  ? "THIRDWEB"
-                  : "CUSTOM_CONTRACT",
               },
               {
                 onSuccess: () => {


### PR DESCRIPTION
**Bug Analysis**
- In payments, thirdweb contract is registered as custom contract
- Occurs when current wallet chainId is different from the chainId of the payments contract being registered (easily replicated for this scenario)
- Contract ABI is not found for { chainId, contractAddress }, so thirdweb type is not detected
- Incorrect flow is used when adding a checkout link due to the wrong contract type

**Changes**
- Bug Fix: Pull contract abi for the payments { chainId, contractAddress } being registered
- Add contract name to the payments contract being registered

**Tests**

- [x] Should register correct contract type when wallet is connected to different chainId than the payments contract being registered
- [x] Should add the name of the contract to the registered payment contract
- [x] Cannot replicate the issue with the bug fix
- [x] Can easily replicate the issue without the bug fix  