### PR TITLE
feat: add Engine txn details drawer

### DIFF
--- a/components/engine/overview/transactions-table.tsx
+++ b/components/engine/overview/transactions-table.tsx
@@ -469,14 +469,14 @@ const TransactionDetailsDrawer = ({
 }) => {
   const { chainIdToChainRecord } = useAllChainsData();
 
-  if (!transaction.chainId) {
+  if (!transaction.chainId || !transaction.status) {
     return null;
   }
 
   const chain = chainIdToChainRecord[parseInt(transaction.chainId)];
   const explorer = chain.explorers?.[0];
 
-  const status = statusDetails[transaction.status];
+  const status = statusDetails[transaction.status as EngineStatus];
 
   return (
     <Drawer isOpen={disclosure.isOpen} onClose={disclosure.onClose} size="sm">

--- a/components/engine/overview/transactions-table.tsx
+++ b/components/engine/overview/transactions-table.tsx
@@ -643,7 +643,7 @@ const TransactionDetailsDrawer = ({
           size="xs"
         >
           {timeline.map((step, index) => (
-            <Step key={index} w="full">
+            <Step key={index} as={Flex} w="full">
               <StepIndicator>
                 <StepStatus
                   complete={<StepIcon />}
@@ -654,7 +654,9 @@ const TransactionDetailsDrawer = ({
 
               <Flex justify="space-between" w="full">
                 <FormLabel m={0}>{step.title}</FormLabel>
-                <Text fontSize="small">{step.description}</Text>
+                <Text fontSize="small" mt={-1}>
+                  {step.description}
+                </Text>
               </Flex>
 
               <StepSeparator />


### PR DESCRIPTION
Add a drawer that shows details Engine txns from the transactions table.

<img width="1368" alt="image" src="https://github.com/thirdweb-dev/dashboard/assets/7673418/4ae70ea1-0606-4046-aea1-621be4418928">
