### PR TITLE
Fallback value for total pinned files

### DIFF
--- a/components/storage/your-files.tsx
+++ b/components/storage/your-files.tsx
@@ -182,7 +182,7 @@ export const YourFilesSection: React.FC = () => {
     [],
   );
   const selectTotalCount = useCallback(
-    (data?: PinnedFilesResponse) => data?.result.count || 0,
+    (data?: PinnedFilesResponse) => data?.result?.count || 0,
     [],
   );
   return (


### PR DESCRIPTION
Related: https://github.com/thirdweb-dev/dashboard/pull/2109

Old:
```
(data?: PinnedFilesResponse) => data?.result.count || 0,
```

New:
```
(data?: PinnedFilesResponse) => data?.result?.count || 0,
```

Error:
![image](https://github.com/thirdweb-dev/dashboard/assets/26052673/f09f569c-b4a3-4f7e-9717-a74bac945a9b)
