### PR TITLE
Fix Split deployment

### DIFF
--- a/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -52,6 +52,7 @@ import {
 import { TrustedForwardersFieldset } from "./trusted-forwarders-fieldset";
 import { DeprecatedAlert } from "components/shared/DeprecatedAlert";
 import { Chain } from "@thirdweb-dev/chains";
+import { useMemo } from "react";
 
 interface CustomContractFormProps {
   ipfsHash: string;
@@ -147,6 +148,18 @@ const CustomContractForm: React.FC<CustomContractFormProps> = ({
     ),
   };
 
+  const transformedQueryData = useMemo(
+    () => ({
+      addToDashboard: true,
+      deployDeterministic: isAccountFactory,
+      saltForCreate2: "",
+      signerAsSalt: true,
+      deployParams: parseDeployParams,
+      recipients: [{ address: connectedWallet, sharesBps: 10000 }],
+    }),
+    [parseDeployParams, isAccountFactory, connectedWallet],
+  );
+
   const form = useForm<{
     addToDashboard: boolean;
     deployDeterministic: boolean;
@@ -161,20 +174,8 @@ const CustomContractForm: React.FC<CustomContractFormProps> = ({
     };
     recipients?: Recipient[];
   }>({
-    defaultValues: {
-      addToDashboard: true,
-      deployDeterministic: isAccountFactory,
-      saltForCreate2: "",
-      signerAsSalt: true,
-      deployParams: parseDeployParams,
-    },
-    values: {
-      addToDashboard: true,
-      deployDeterministic: isAccountFactory,
-      saltForCreate2: "",
-      signerAsSalt: true,
-      deployParams: parseDeployParams,
-    },
+    defaultValues: transformedQueryData,
+    values: transformedQueryData,
     resetOptions: {
       keepDirty: true,
       keepDirtyValues: true,
@@ -372,7 +373,7 @@ const CustomContractForm: React.FC<CustomContractFormProps> = ({
               )}
               {hasRoyalty && <RoyaltyFieldset form={form} />}
               {hasPrimarySale && <PrimarySaleFieldset form={form} />}
-              {isSplit && <SplitFieldset form={form} />}
+              {isSplit && <SplitFieldset form={form} />} 
               {hasTrustedForwarders && (
                 <TrustedForwardersFieldset
                   form={form}

--- a/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -121,32 +121,40 @@ const CustomContractForm: React.FC<CustomContractFormProps> = ({
     !isFactoryDeployment &&
     (fullPublishMetadata.data?.name.includes("AccountFactory") || false);
 
-  const parseDeployParams = {
-    ...deployParams.reduce(
-      (acc, param) => {
-        if (!param.name) {
-          param.name = "*";
-        }
+  const parsedDeployParams = useMemo(
+    () => ({
+      ...deployParams.reduce(
+        (acc, param) => {
+          if (!param.name) {
+            param.name = "*";
+          }
 
-        acc[param.name] = replaceTemplateValues(
-          fullPublishMetadata.data?.constructorParams?.[param.name]
-            ?.defaultValue
-            ? fullPublishMetadata.data?.constructorParams?.[param.name]
-                ?.defaultValue || ""
-            : param.name === "_royaltyBps" || param.name === "_platformFeeBps"
-              ? "0"
-              : "",
-          param.type,
-          {
-            connectedWallet,
-            chainId: selectedChain,
-          },
-        );
-        return acc;
-      },
-      {} as Record<string, string>,
-    ),
-  };
+          acc[param.name] = replaceTemplateValues(
+            fullPublishMetadata.data?.constructorParams?.[param.name]
+              ?.defaultValue
+              ? fullPublishMetadata.data?.constructorParams?.[param.name]
+                  ?.defaultValue || ""
+              : param.name === "_royaltyBps" || param.name === "_platformFeeBps"
+                ? "0"
+                : "",
+            param.type,
+            {
+              connectedWallet,
+              chainId: selectedChain,
+            },
+          );
+          return acc;
+        },
+        {} as Record<string, string>,
+      ),
+    }),
+    [
+      deployParams,
+      fullPublishMetadata.data?.constructorParams,
+      connectedWallet,
+      selectedChain,
+    ],
+  );
 
   const transformedQueryData = useMemo(
     () => ({
@@ -154,10 +162,10 @@ const CustomContractForm: React.FC<CustomContractFormProps> = ({
       deployDeterministic: isAccountFactory,
       saltForCreate2: "",
       signerAsSalt: true,
-      deployParams: parseDeployParams,
+      deployParams: parsedDeployParams,
       recipients: [{ address: connectedWallet, sharesBps: 10000 }],
     }),
-    [parseDeployParams, isAccountFactory, connectedWallet],
+    [parsedDeployParams, isAccountFactory, connectedWallet],
   );
 
   const form = useForm<{

--- a/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -163,7 +163,7 @@ const CustomContractForm: React.FC<CustomContractFormProps> = ({
       saltForCreate2: "",
       signerAsSalt: true,
       deployParams: parsedDeployParams,
-      recipients: [{ address: connectedWallet, sharesBps: 10000 }],
+      recipients: [{ address: connectedWallet || "", sharesBps: 10000 }],
     }),
     [parsedDeployParams, isAccountFactory, connectedWallet],
   );

--- a/components/contract-components/contract-deploy-form/custom-contract.tsx
+++ b/components/contract-components/contract-deploy-form/custom-contract.tsx
@@ -373,7 +373,7 @@ const CustomContractForm: React.FC<CustomContractFormProps> = ({
               )}
               {hasRoyalty && <RoyaltyFieldset form={form} />}
               {hasPrimarySale && <PrimarySaleFieldset form={form} />}
-              {isSplit && <SplitFieldset form={form} />} 
+              {isSplit && <SplitFieldset form={form} />}
               {hasTrustedForwarders && (
                 <TrustedForwardersFieldset
                   form={form}

--- a/components/contract-components/contract-deploy-form/split-fieldset.tsx
+++ b/components/contract-components/contract-deploy-form/split-fieldset.tsx
@@ -7,6 +7,7 @@ import {
   Flex,
   FormControl,
   IconButton,
+  Input,
 } from "@chakra-ui/react";
 import { IoMdAdd } from "@react-icons/all-files/io/IoMdAdd";
 import { IoMdRemove } from "@react-icons/all-files/io/IoMdRemove";
@@ -32,11 +33,11 @@ export const SplitFieldset: React.FC<SplitFieldsetProps> = ({ form }) => {
     control: form.control,
   });
 
-  useEffect(() => {
+/*   useEffect(() => {
     if (fields.length === 0) {
       append({ address: "", sharesBps: 10000 }, { shouldFocus: false });
     }
-  }, [fields, append]);
+  }, [fields, append]); */
 
   const totalShares =
     form

--- a/components/contract-components/contract-deploy-form/split-fieldset.tsx
+++ b/components/contract-components/contract-deploy-form/split-fieldset.tsx
@@ -7,7 +7,6 @@ import {
   Flex,
   FormControl,
   IconButton,
-  Input,
 } from "@chakra-ui/react";
 import { IoMdAdd } from "@react-icons/all-files/io/IoMdAdd";
 import { IoMdRemove } from "@react-icons/all-files/io/IoMdRemove";

--- a/components/contract-components/contract-deploy-form/split-fieldset.tsx
+++ b/components/contract-components/contract-deploy-form/split-fieldset.tsx
@@ -14,7 +14,6 @@ import { IoMdRemove } from "@react-icons/all-files/io/IoMdRemove";
 import { BasisPointsInput } from "components/inputs/BasisPointsInput";
 import { SolidityInput } from "contract-ui/components/solidity-inputs";
 import { constants } from "ethers";
-import { useEffect } from "react";
 import { UseFormReturn, useFieldArray } from "react-hook-form";
 import { Button, FormErrorMessage, Heading, Text } from "tw-components";
 
@@ -32,12 +31,6 @@ export const SplitFieldset: React.FC<SplitFieldsetProps> = ({ form }) => {
     name: "recipients",
     control: form.control,
   });
-
-/*   useEffect(() => {
-    if (fields.length === 0) {
-      append({ address: "", sharesBps: 10000 }, { shouldFocus: false });
-    }
-  }, [fields, append]); */
 
   const totalShares =
     form

--- a/components/inputs/BasisPointsInput.tsx
+++ b/components/inputs/BasisPointsInput.tsx
@@ -39,7 +39,9 @@ export const BasisPointsInput: React.FC<BasisPointsInputProps> = ({
     if (validValue && validValue.length) {
       onChange(Math.floor(parseFloat(validValue[0] || "0") * 100));
     }
-  }, [stringValue, onChange]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stringValue]);
 
   return (
     <InputGroup {...restInputProps}>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to address linting warnings related to exhaustive-deps in React hooks.

### Detailed summary
- Added eslint-disable-next-line for `react-hooks/exhaustive-deps` in `BasisPointsInput.tsx`
- Removed unused `useEffect` in `SplitFieldset.tsx`
- Refactored `parseDeployParams` to `parsedDeployParams` using `useMemo` in `CustomContractForm.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->