### PR TITLE
Add payment method tracking on op sponsorship

### DIFF
--- a/components/onboarding/ApplyForOpCreditsModal.tsx
+++ b/components/onboarding/ApplyForOpCreditsModal.tsx
@@ -16,12 +16,13 @@ import {
 } from "@chakra-ui/react";
 import { Button, Card, Heading, Text, Badge } from "tw-components";
 import { useAccount, AccountPlan } from "@3rdweb-sdk/react/hooks/useApi";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { OnboardingBilling } from "./Billing";
 import { OnboardingModal } from "./Modal";
 import { PlanCard } from "./PlanCard";
 import { ApplyForOpCreditsForm } from "./ApplyForOpCreditsForm";
 import { useLocalStorage } from "hooks/useLocalStorage";
+import { useTrack } from "hooks/analytics/useTrack";
 
 export type CreditsRecord = {
   title: string;
@@ -93,6 +94,15 @@ export const ApplyForOpCreditsModal: React.FC<ApplyForOpCreditsModalProps> = ({
     `appliedForOpGrant-${(account?.data && account.data.id) || ""}`,
     false,
   );
+  const trackEvent = useTrack();
+
+  useEffect(() => {
+    trackEvent({
+      category: "op-sponsorship",
+      action: "modal",
+      label: "view-modal",
+    });
+  }, [trackEvent]);
 
   const hasValidPayment = account.data?.status === "validPayment";
 
@@ -170,7 +180,14 @@ export const ApplyForOpCreditsModal: React.FC<ApplyForOpCreditsModalProps> = ({
                           charged.{" "}
                           <Text
                             as="span"
-                            onClick={onPaymentMethodOpen}
+                            onClick={() => {
+                              onPaymentMethodOpen();
+                              trackEvent({
+                                category: "op-sponsorship",
+                                action: "add-payment-method",
+                                label: "open",
+                              });
+                            }}
                             color="blue.500"
                             cursor="pointer"
                           >
@@ -241,8 +258,22 @@ export const ApplyForOpCreditsModal: React.FC<ApplyForOpCreditsModalProps> = ({
         onClose={onPaymentMethodClose}
       >
         <OnboardingBilling
-          onSave={onPaymentMethodClose}
-          onCancel={onPaymentMethodClose}
+          onSave={() => {
+            onPaymentMethodClose();
+            trackEvent({
+              category: "op-sponsorship",
+              action: "add-payment-method",
+              label: "success",
+            });
+          }}
+          onCancel={() => {
+            onPaymentMethodClose();
+            trackEvent({
+              category: "op-sponsorship",
+              action: "add-payment-method",
+              label: "cancel",
+            });
+          }}
         />
       </OnboardingModal>
     </>

--- a/components/onboarding/OpCreditsGrantedModal.tsx
+++ b/components/onboarding/OpCreditsGrantedModal.tsx
@@ -16,21 +16,10 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { ChakraNextImage } from "components/Image";
-import { useTrack } from "hooks/analytics/useTrack";
-import { useEffect } from "react";
 import { Text, Card, Heading } from "tw-components";
 
 export const OpCreditsGrantedModal = () => {
   const { isOpen, onClose } = useDisclosure();
-  const trackEvent = useTrack();
-
-  useEffect(() => {
-    trackEvent({
-      category: "op-sponsorship",
-      action: "modal",
-      label: "view-modal",
-    });
-  }, [trackEvent]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to implement tracking events using `useTrack` in the `ApplyForOpCreditsModal` and `OpCreditsGrantedModal`.

### Detailed summary
- Added `useTrack` for tracking events in `ApplyForOpCreditsModal`
- Added tracking events for button clicks in `ApplyForOpCreditsModal`
- Added tracking events for payment method actions in `ApplyForOpCreditsModal`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->