### PR TITLE
Handle line breaks on nft description

### DIFF
--- a/contract-ui/tabs/nfts/components/token-id.tsx
+++ b/contract-ui/tabs/nfts/components/token-id.tsx
@@ -119,7 +119,7 @@ export const TokenIdPage: React.FC<TokenIdPageProps> = ({
         <Flex flexDir="column" gap={2}>
           <Heading size="title.lg">{nft.metadata.name}</Heading>
           {nft.metadata?.description && (
-            <Text size="label.md" noOfLines={6}>
+            <Text size="label.md" noOfLines={50} whiteSpace="pre-wrap">
               {nft.metadata.description}
             </Text>
           )}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR increases the number of lines displayed for NFT descriptions in the token-id component.

### Detailed summary
- Increased number of lines displayed for NFT descriptions from 6 to 50.
- Changed white space styling to `pre-wrap` for better text formatting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->