### PR TITLE
re-order nft contracts in explore

### DIFF
--- a/data/explore.ts
+++ b/data/explore.ts
@@ -34,15 +34,15 @@ const NFTS = {
   description:
     "NFT Collections, Editions, Drops and everything else NFT-related.",
   contracts: [
-    "thirdweb.eth/LoyaltyCard",
-    "doubledev.eth/ERC4907",
+    "thirdweb.eth/DropERC721",
+    "thirdweb.eth/OpenEditionERC721",
     "thirdweb.eth/TokenERC721",
+    "thirdweb.eth/DropERC1155",
     "thirdweb.eth/TokenERC1155",
     "thirdweb.eth/Pack",
-    "thirdweb.eth/OpenEditionERC721",
     "flairsdk.eth/ERC721CommunityStream",
-    "thirdweb.eth/DropERC721",
-    "thirdweb.eth/DropERC1155",
+    "thirdweb.eth/LoyaltyCard",
+    "doubledev.eth/ERC4907",
     "thirdweb.eth/Multiwrap",
     "kronickatz.eth/ERC721NESDrop",
   ],
@@ -197,9 +197,7 @@ export function getCategory(id: string): ExploreCategory | null {
 
 type ExploreCategoryName = keyof typeof CATEGORIES;
 
-function isExploreCategory(
-  category: string,
-): category is ExploreCategoryName {
+function isExploreCategory(category: string): category is ExploreCategoryName {
   return category in CATEGORIES;
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates NFT-related contracts and adds new ones. It also refactors the `isExploreCategory` function for better type checking.

### Detailed summary
- Updated NFT-related contracts to `DropERC721`, `OpenEditionERC721`, and `DropERC1155`
- Refactored `isExploreCategory` function for improved type checking

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->