### PR TITLE
test: add tests for chain-page, contract-page, and publisher-page

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,28 @@
+# E2E testing setup
+
+This directory contains the end-to-end (E2E) testing setup for the project.
+
+## Adding a test
+
+1. create a new file in this directory with the `.spec.ts` extension
+2. copy the paterns from the existing tests
+
+## Running the tests locally
+
+To run the tests locally, you can use the following command:
+
+```bash
+pnpm playwright
+```
+
+## CI (vercel + checkly)
+
+These tests are run automatically on every pull request as part of the vercel build (after the build completes we check if the tests pass and then we deploy the changes to the preview environment).
+
+Your PR will be _blocked_ from deploying if these tests fail.
+
+### Updating the tests in checkly
+
+1. Create the tests
+2. make sure they run locally
+3. push the changes to the repository and run `pnpm update-checkly` to update the checkly tests. (Requires checkly cli being signed in, meaning you need to have checkly access.)

--- a/tests/chain-page.spec.ts
+++ b/tests/chain-page.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page, baseURL }) => {
+  await page.goto(baseURL ? `${baseURL}/1` : "/1");
+});
+
+test.describe("Chain Page", () => {
+  test("redirects chain-id to correct slug", async ({ page }) => {
+    // Expect the page to have the correct title.
+    const pageUrl = page.url();
+    expect(pageUrl).toContain("/ethereum");
+  });
+});

--- a/tests/contract-page.spec.ts
+++ b/tests/contract-page.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page, baseURL }) => {
+  await page.goto(
+    baseURL
+      ? `${baseURL}/1/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D`
+      : "/1/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+  );
+});
+
+test.describe("Contract Page", () => {
+  test("BAYC", async ({ page }) => {
+    await page.waitForLoadState("networkidle");
+    // Expect the page to have the correct title.
+    expect(await page.title()).toBe(
+      "BoredApeYachtClub (BAYC) | Ethereum Smart Contract | thirdweb",
+    );
+    // expect the page to have the correct h1 tag.
+    expect(await page.locator("h1").textContent()).toBe("BoredApeYachtClub");
+
+    // find the extensions header
+    const nftTabLinkEl = page.locator("a", { hasText: "NFTs" }).first();
+    expect(await nftTabLinkEl.textContent()).toBe("NFTs");
+  });
+});

--- a/tests/contract-page.spec.ts
+++ b/tests/contract-page.spec.ts
@@ -11,7 +11,7 @@ test.beforeEach(async ({ page, baseURL }) => {
 test.describe("Contract Page", () => {
   test("BAYC", async ({ page }) => {
     // give it some time to load
-    await wait(2000);
+    await wait(5000);
     // Expect the page to have the correct title.
     expect(await page.title()).toBe(
       "BoredApeYachtClub (BAYC) | Ethereum Smart Contract | thirdweb",

--- a/tests/contract-page.spec.ts
+++ b/tests/contract-page.spec.ts
@@ -10,7 +10,8 @@ test.beforeEach(async ({ page, baseURL }) => {
 
 test.describe("Contract Page", () => {
   test("BAYC", async ({ page }) => {
-    await page.waitForLoadState("networkidle");
+    // give it some time to load
+    await wait(2000);
     // Expect the page to have the correct title.
     expect(await page.title()).toBe(
       "BoredApeYachtClub (BAYC) | Ethereum Smart Contract | thirdweb",
@@ -23,3 +24,7 @@ test.describe("Contract Page", () => {
     expect(await nftTabLinkEl.textContent()).toBe("NFTs");
   });
 });
+
+async function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/publisher-page.spec.ts
+++ b/tests/publisher-page.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page, baseURL }) => {
+  await page.goto(baseURL ? `${baseURL}/thirdweb.eth` : "/thirdweb.eth");
+});
+
+test.describe("Publisher Page", () => {
+  test("thirdweb.eth", async ({ page }) => {
+    // Expect the page to have the correct title.
+    expect(await page.locator("h1").textContent()).toBe("thirdweb.eth");
+    expect(await page.locator("h2").nth(1).textContent()).toBe(
+      "Published contracts",
+    );
+    // first h2 header, then 10 elements in first table -> should be 12th
+    expect(await page.locator("h2").nth(12).textContent()).toBe(
+      "Deployed contracts",
+    );
+
+    // 13 h2 headers to start
+    expect((await page.locator("h2").all()).length).toBe(13);
+
+    const publishedContractsShowMoreButton = page
+      .locator("text=Show more")
+      .first();
+    await publishedContractsShowMoreButton.click();
+    // should load 10 more elements
+    expect((await page.locator("h2").all()).length).toBe(23);
+  });
+});


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds end-to-end (E2E) tests for `Chain Page`, `Contract Page`, and `Publisher Page` using Playwright. 

### Detailed summary
- Added E2E tests for Chain Page, Contract Page, and Publisher Page
- Created test files for each page
- Implemented test scenarios for page redirection, title validation, element checks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->