### PR TITLE
chore: homepage cleanup

### DIFF
--- a/components/homepage/sections/HomePageCard.tsx
+++ b/components/homepage/sections/HomePageCard.tsx
@@ -4,7 +4,7 @@ import { LandingDesktopMobileImage } from "components/landing-pages/desktop-mobi
 import { StaticImageData } from "next/image";
 import React, { ReactNode } from "react";
 import { BsFillLightningChargeFill } from "react-icons/bs";
-import { ButtonProps, Heading, Text, TrackedLinkButton } from "tw-components";
+import { Heading, Text, TrackedLinkButton } from "tw-components";
 
 interface HomePageCardProps {
   title: string;
@@ -13,10 +13,8 @@ interface HomePageCardProps {
   miniTitle: string;
   ctaLink: string;
   ctaText: string;
-  contactUsButtonMaxWidth?: ButtonProps["maxWidth"];
+  label: string;
   customContactUsComponent?: ReactNode;
-  contactUsText?: string;
-  contactUsLink?: string;
   image: StaticImageData;
   mobileImage?: StaticImageData;
   TRACKING_CATEGORY: string;
@@ -30,11 +28,9 @@ const HomePageCard = ({
   image,
   mobileImage,
   ctaLink,
-  contactUsButtonMaxWidth,
   customContactUsComponent,
-  contactUsText,
-  contactUsLink,
   ctaText,
+  label,
   TRACKING_CATEGORY,
 }: HomePageCardProps) => {
   return (
@@ -97,29 +93,13 @@ const HomePageCard = ({
               color="black"
               href={ctaLink}
               category={TRACKING_CATEGORY}
-              label={ctaText.replaceAll(" ", "-").toLowerCase()}
+              label={label}
               fontWeight="bold"
               maxW="190px"
               leftIcon={<Icon as={BsFillLightningChargeFill} boxSize={4} />}
             >
               {ctaText}
             </TrackedLinkButton>
-
-            {contactUsLink && contactUsText && (
-              <TrackedLinkButton
-                py={6}
-                px={8}
-                variant="outline"
-                maxW={contactUsButtonMaxWidth}
-                href={contactUsLink}
-                category={TRACKING_CATEGORY}
-                label={contactUsText.replaceAll(" ", "-").toLowerCase()}
-                fontWeight="bold"
-                w="full"
-              >
-                {contactUsText}
-              </TrackedLinkButton>
-            )}
 
             {customContactUsComponent && customContactUsComponent}
           </Flex>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -48,6 +48,7 @@ const HomePage: ThirdwebNextPage = () => {
             miniTitle="Connect"
             miniImage={require("public/assets/landingpage/connect-icon.png")}
             ctaText="Get started"
+            label="get-started-connect"
             ctaLink="/connect"
             image={require("public/assets/landingpage/connect-hero.png")}
             mobileImage={require("public/assets/landingpage/connect-hero.png")}
@@ -59,6 +60,7 @@ const HomePage: ThirdwebNextPage = () => {
             miniTitle="Engine"
             miniImage={require("public/assets/landingpage/engine-icon.png")}
             ctaText="Get started"
+            label="get-started-engine"
             ctaLink="/engine"
             image={require("public/assets/landingpage/engine-hero.png")}
             mobileImage={require("public/assets/landingpage/engine-hero.png")}
@@ -70,6 +72,7 @@ const HomePage: ThirdwebNextPage = () => {
             miniTitle="Contracts"
             miniImage={require("public/assets/landingpage/contracts-icon.png")}
             ctaText="Get started"
+            label="get-started-contracts"
             ctaLink="/contracts"
             image={require("public/assets/landingpage/contracts-hero.png")}
             mobileImage={require("public/assets/landingpage/contracts-hero.png")}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a new `label` prop to `HomePageCard` component and remove unnecessary `contactUs` related props.

### Detailed summary
- Added `label` prop to `HomePageCard` component
- Removed `contactUsButtonMaxWidth`, `contactUsText`, and `contactUsLink` props
- Updated usage of `ctaText` with `label` prop in `HomePageCard` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->