### PR TITLE
chore: redirect onchain icon to contracts

### DIFF
--- a/components/homepage/sections/HeroSection.tsx
+++ b/components/homepage/sections/HeroSection.tsx
@@ -169,7 +169,7 @@ export const HeroSection = ({ TRACKING_CATEGORY }: HeroSectionProps) => {
           </TrackedLink>
 
           <TrackedLink
-            href="/explore"
+            href="/contracts"
             category={TRACKING_CATEGORY}
             label="onchain-icon"
           >


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the link in `HeroSection.tsx` from "/explore" to "/contracts".

### Detailed summary
- Updated link from "/explore" to "/contracts" in `TrackedLink` component in `HeroSection.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->