### PR TITLE
chore: remove "About us" in nav

### DIFF
--- a/components/product-pages/common/nav/data.ts
+++ b/components/product-pages/common/nav/data.ts
@@ -215,14 +215,6 @@ export const SOLUTIONS: SectionItemProps[] = [
 
 export const COMPANY: SectionItemProps[] = [
   {
-    name: "About us",
-    label: "about",
-    description: "Learn more about our company",
-    link: "/about",
-    icon: require("public/assets/tw-icons/general.png"),
-    section: "company",
-  },
-  {
     name: "Mission",
     label: "mission",
     description: "Why we work in web3",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the "About us" section item from the COMPANY section in `data.ts`.

### Detailed summary
- Removed the "About us" section item from the COMPANY section in `data.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->