### PR TITLE
feat: Add getBaseURL function for test setup

### DIFF
--- a/tests/chain-page.spec.ts
+++ b/tests/chain-page.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "@playwright/test";
+import { getBaseURL } from "./setup";
 
 test.beforeEach(async ({ page, baseURL }) => {
-  await page.goto(baseURL ? `${baseURL}/1` : "/1");
+  await page.goto(`${getBaseURL(baseURL)}/1`);
 });
 
 test.describe("Chain Page", () => {

--- a/tests/contract-page.spec.ts
+++ b/tests/contract-page.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { getBaseURL } from "./setup";
+import { getBaseURL, waitForPageLoad } from "./setup";
 
 test.beforeEach(async ({ page, baseURL }) => {
   await page.goto(
@@ -10,7 +10,10 @@ test.beforeEach(async ({ page, baseURL }) => {
 test.describe("Contract Page", () => {
   test("BAYC", async ({ page }) => {
     // give it some time to load
-    await wait(10000);
+    await waitForPageLoad(page, {
+      loadTimeout: 10000,
+      waitAfterLoad: 5000,
+    });
     // Expect the page to have the correct title.
     expect(await page.title()).toBe(
       "BoredApeYachtClub (BAYC) | Ethereum Smart Contract | thirdweb",
@@ -23,7 +26,3 @@ test.describe("Contract Page", () => {
     expect(await nftTabLinkEl.textContent()).toBe("NFTs");
   });
 });
-
-async function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/tests/contract-page.spec.ts
+++ b/tests/contract-page.spec.ts
@@ -1,10 +1,9 @@
 import { test, expect } from "@playwright/test";
+import { getBaseURL } from "./setup";
 
 test.beforeEach(async ({ page, baseURL }) => {
   await page.goto(
-    baseURL
-      ? `${baseURL}/1/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D`
-      : "/1/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+    `${getBaseURL(baseURL)}/1/0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D`,
   );
 });
 

--- a/tests/contract-page.spec.ts
+++ b/tests/contract-page.spec.ts
@@ -12,7 +12,7 @@ test.describe("Contract Page", () => {
     // give it some time to load
     await waitForPageLoad(page, {
       loadTimeout: 10000,
-      waitAfterLoad: 5000,
+      waitAfterLoad: 15000,
     });
     // Expect the page to have the correct title.
     expect(await page.title()).toBe(

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "@playwright/test";
+import { getBaseURL } from "./setup";
 
 test.beforeEach(async ({ page, baseURL }) => {
-  await page.goto(baseURL || "/");
+  await page.goto(getBaseURL(baseURL));
 });
 
 test.describe("Homepage", () => {

--- a/tests/publisher-page.spec.ts
+++ b/tests/publisher-page.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "@playwright/test";
+import { getBaseURL } from "./setup";
 
 test.beforeEach(async ({ page, baseURL }) => {
-  await page.goto(baseURL ? `${baseURL}/thirdweb.eth` : "/thirdweb.eth");
+  await page.goto(`${getBaseURL(baseURL)}/thirdweb.eth`);
 });
 
 test.describe("Publisher Page", () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,9 @@
+export function getBaseURL(url: string | void) {
+  if (process.env.ENVIRONMENT_URL) {
+    url = process.env.ENVIRONMENT_URL;
+  }
+  if (!url) {
+    url = "https://thirdweb.com/";
+  }
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,5 @@
+import { Page } from "@playwright/test";
+
 export function getBaseURL(url: string | void) {
   if (process.env.ENVIRONMENT_URL) {
     url = process.env.ENVIRONMENT_URL;
@@ -6,4 +8,22 @@ export function getBaseURL(url: string | void) {
     url = "https://thirdweb.com/";
   }
   return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+async function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitForPageLoad(
+  page: Page,
+  options: { loadTimeout: number; waitAfterLoad?: number },
+) {
+  await Promise.race([
+    page.waitForLoadState("load"),
+    wait(options.loadTimeout),
+  ]);
+
+  if (options.waitAfterLoad) {
+    await wait(options.waitAfterLoad);
+  }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates test scripts to use a centralized `getBaseURL` function and adds a `waitForPageLoad` function for better test control.

### Detailed summary
- Centralized `getBaseURL` function for test scripts
- Added `waitForPageLoad` function for better test control
- Updated test scripts to use `getBaseURL` function for URL handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->