### PR TITLE
Update Mumbai deprecation alert link

### DIFF
--- a/components/shared/DeprecatedAlert.tsx
+++ b/components/shared/DeprecatedAlert.tsx
@@ -84,7 +84,7 @@ export const DeprecatedAlert: React.FC<DeprecatedAlertProps> = ({ chain }) => {
             <>
               <br />
               We recommend switching to{" "}
-              <Link href={recommendedChain.slug} color="primary.500">
+              <Link href={`/${recommendedChain.slug}`} color="primary.500">
                 {recommendedChain.name}
               </Link>{" "}
               to continue testing your smart contracts.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `Link` component in `DeprecatedAlert.tsx` to use a dynamic `href` value.

### Detailed summary
- Updated `Link` component `href` prop to use template literal for dynamic value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->