### PR TITLE
chore: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Order is important; the last matching pattern takes the most precedence.
+
+# Connect team owns everything by default
+
+- @jnsdls @joaquim-verges @MananTank
+
+# pages overrides
+
+src/pages/dashboard/engine/ @arcoraven
+
+# configurations
+
+.github/ @jnsdls


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the CODEOWNERS file to specify ownership of different directories and files for better code management.

### Detailed summary
- Updated default team ownership in CODEOWNERS file
- Added specific ownership for 'src/pages/dashboard/engine/'
- Added specific ownership for '.github/' folder

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->