### PR TITLE
chore: Fallback to Polygon Amoy

### DIFF
--- a/src/components/buttons/MismatchButton.tsx
+++ b/src/components/buttons/MismatchButton.tsx
@@ -330,9 +330,9 @@ const UpsellTestnetNotice: React.FC<{
       label: "switch-to-testnet",
     });
     if (actuallyCanAttemptSwitch && chain) {
-      await switchNetwork(80001);
+      await switchNetwork(80002);
     }
-    onChainSelect(80001);
+    onChainSelect(80002);
     onClose();
   }, [
     chain,
@@ -372,10 +372,9 @@ const UpsellTestnetNotice: React.FC<{
         // isLoading={network.loading}
         isDisabled={!actuallyCanAttemptSwitch}
         colorScheme="orange"
-        textTransform="capitalize"
         noOfLines={1}
       >
-        Switch wallet to Mumbai
+        Switch wallet to Polygon Amoy Testnet
       </Button>
 
       {!actuallyCanAttemptSwitch && (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the button text and network switch logic in `MismatchButton.tsx`.

### Detailed summary
- Updated button text to "Switch wallet to Polygon Amoy Testnet"
- Changed network switch from Mumbai (80001) to Polygon Amoy Testnet (80002)

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->