### PR TITLE
Add BaseSepolia to supported chains for payments, remove Goerli

### DIFF
--- a/src/@3rdweb-sdk/react/hooks/usePayments.ts
+++ b/src/@3rdweb-sdk/react/hooks/usePayments.ts
@@ -8,6 +8,7 @@ import {
   AvalancheFuji,
   Base,
   BaseGoerli,
+  BaseSepoliaTestnet,
   Binance,
   BinanceTestnet,
   Ethereum,
@@ -86,14 +87,13 @@ export const validPaymentsChainIdsMainnets: number[] = [
 ];
 
 const validPaymentsChainIdsTestnets: number[] = [
-  Goerli.chainId,
   Sepolia.chainId,
   Mumbai.chainId,
   AvalancheFuji.chainId,
   OptimismGoerli.chainId,
   ArbitrumGoerli.chainId,
   BinanceTestnet.chainId,
-  BaseGoerli.chainId,
+  BaseSepoliaTestnet.chainId,
   ZoraTestnet.chainId,
   ArbitrumSepolia.chainId,
   FrameTestnet.chainId,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for the `BaseSepoliaTestnet` chain ID and removes `Sepolia` chain ID in the `usePayments` hook.

### Detailed summary
- Added `BaseSepoliaTestnet` chain ID
- Removed `Sepolia` chain ID

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->