### PR TITLE
Fix AA page crash - Remove usages of `getChainByChainId`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-persist-client": "^4.36.1",
     "@tanstack/react-table": "^8.15.3",
-    "@thirdweb-dev/chains": "0.1.86",
+    "@thirdweb-dev/chains": "0.1.91",
     "@thirdweb-dev/react": "4.4.29",
     "@thirdweb-dev/sdk": "4.0.55",
     "@thirdweb-dev/service-utils": "0.4.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ dependencies:
     specifier: ^8.15.3
     version: 8.15.3(react-dom@18.2.0)(react@18.2.0)
   '@thirdweb-dev/chains':
-    specifier: 0.1.86
-    version: 0.1.86
+    specifier: 0.1.91
+    version: 0.1.91
   '@thirdweb-dev/react':
     specifier: 4.4.29
     version: 4.4.29(@babel/core@7.23.9)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/bignumber@5.7.0)(@ethersproject/properties@5.7.0)(@thirdweb-dev/sdk@4.0.55)(@types/react-dom@18.2.23)(@types/react@18.2.73)(ethers@5.7.2)(fastify@4.26.2)(localforage@1.10.0)(next@14.1.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.3)
@@ -6558,6 +6558,11 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
+  /@thirdweb-dev/chains@0.1.91:
+    resolution: {integrity: sha512-LWsYYMd9tmJd8lzXxiMNera+EaAmX7A1kjHHuYhWHge4+pSJ3wPG4Ph2abFMk5dz31GrXKroE+zDHOffXJlsXQ==}
+    engines: {node: '>=18'}
+    dev: false
+
   /@thirdweb-dev/contracts-js@1.3.20(ethers@5.7.2):
     resolution: {integrity: sha512-Gx+XFrFhtGo5swDknqCfzDKMRc+EwgfFmC1AsW2jGvzSLo0egBbz1NA+WvDxbLQJAi6rhSuomuX99tYN3nVzyw==}
     peerDependencies:
@@ -11162,6 +11167,7 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: false
+    bundledDependencies: false
 
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}

--- a/src/components/contract-components/hooks.ts
+++ b/src/components/contract-components/hooks.ts
@@ -21,7 +21,7 @@ import {
   Zksync,
   ZksyncEraGoerliTestnetDeprecated,
   ZksyncSepoliaTestnet,
-  getChainByChainId,
+  getChainByChainIdAsync,
 } from "@thirdweb-dev/chains";
 import {
   useAddress,
@@ -941,9 +941,8 @@ export function useCustomFactoryAbi(contractAddress: string, chainId: number) {
   return useQuery(
     ["custom-factory-abi", { contractAddress, chainId }],
     async () => {
-      const chain = getChainByChainId(chainId);
+      const chain = await getChainByChainIdAsync(chainId);
       const sdk = getThirdwebSDK(chainId, getDashboardChainRpc(chain));
-      invariant(sdk, "sdk is not defined");
 
       return (await sdk.getContract(contractAddress)).abi;
     },

--- a/src/components/smart-wallets/AccountFactories/factory-contracts.tsx
+++ b/src/components/smart-wallets/AccountFactories/factory-contracts.tsx
@@ -1,11 +1,13 @@
 import { createColumnHelper } from "@tanstack/react-table";
-import { getChainByChainId } from "@thirdweb-dev/chains";
+import { getChainByChainIdAsync } from "@thirdweb-dev/chains";
 import { TWTable } from "components/shared/TWTable";
 import { Text } from "tw-components";
 import { shortenIfAddress } from "utils/usedapp-external";
 import { AsyncFactoryAccountCell } from "components/smart-wallets/AccountFactories/account-cell";
 import { AsyncContractNameCell } from "components/contract-components/tables/cells";
 import { BasicContract } from "contract-ui/types/types";
+import { useQuery } from "@tanstack/react-query";
+import { Skeleton } from "@chakra-ui/react";
 
 interface FactoryContractsProps {
   contracts: BasicContract[];
@@ -22,7 +24,9 @@ const columns = [
   }),
   columnHelper.accessor("chainId", {
     header: "Network",
-    cell: (cell) => <Text>{getChainByChainId(cell.getValue()).name}</Text>,
+    cell: (cell) => {
+      return <NetworkName id={cell.getValue()} />;
+    },
   }),
   columnHelper.accessor("address", {
     header: "Contract address",
@@ -35,6 +39,19 @@ const columns = [
     },
   }),
 ];
+
+function NetworkName(props: { id: number }) {
+  const chainQuery = useQuery({
+    queryKey: ["getChainByChainIdAsync", props.id],
+    queryFn: () => getChainByChainIdAsync(props.id),
+  });
+
+  return (
+    <Skeleton isLoaded={!!chainQuery.data}>
+      <Text>{chainQuery.data?.name || "..."}</Text>
+    </Skeleton>
+  );
+}
 
 export const FactoryContracts: React.FC<FactoryContractsProps> = ({
   contracts,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update dependencies and improve asynchronous handling in chain retrieval functions.

### Detailed summary
- Updated `@thirdweb-dev/chains` dependency version to `0.1.91`
- Replaced synchronous `getChainByChainId` with asynchronous `getChainByChainIdAsync`
- Modified functions to handle asynchronous chain retrieval
- Added a new `NetworkName` component for displaying network names asynchronously

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->