### PR TITLE
fix: Handle error when fetching contract info and return notFound

### DIFF
--- a/src/components/contract-components/hooks.ts
+++ b/src/components/contract-components/hooks.ts
@@ -263,7 +263,15 @@ export async function fetchAllVersions(
   for (let i = 0; i < allVersions.length; i++) {
     const contractInfo = await sdk
       .getPublisher()
-      .fetchPublishedContractInfo(allVersions[i]);
+      .fetchPublishedContractInfo(allVersions[i])
+      .catch(() => {
+        console.error(
+          `failed to fetchPublishedContractInfo for metadataUri: ${allVersions[i].metadataUri} - ignoring version`,
+        );
+      });
+    if (!contractInfo) {
+      continue;
+    }
 
     publishedVersions.unshift({
       ...allVersions[i],

--- a/src/components/contract-components/hooks.ts
+++ b/src/components/contract-components/hooks.ts
@@ -268,6 +268,7 @@ export async function fetchAllVersions(
         console.error(
           `failed to fetchPublishedContractInfo for metadataUri: ${allVersions[i].metadataUri} - ignoring version`,
         );
+        return null;
       });
     if (!contractInfo) {
       continue;

--- a/src/pages/publish/[...paths].tsx
+++ b/src/pages/publish/[...paths].tsx
@@ -96,7 +96,7 @@ export const getStaticProps: GetStaticProps<PublishPageProps> = async (ctx) => {
       ["all-releases", address, contractName],
       () => fetchAllVersions(polygonSdk, address, contractName),
     );
-  } catch (error) {
+  } catch {
     return {
       notFound: true,
     } as const;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves error handling in fetching contract info and handling not found cases in the publish page.

### Detailed summary
- Improved error handling in fetching contract info
- Added logging for failed fetch attempts
- Ignoring versions with missing contract info

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->