### PR TITLE
templates fix

### DIFF
--- a/src/pages/templates.tsx
+++ b/src/pages/templates.tsx
@@ -40,7 +40,8 @@ export const templates: TemplateCardProps[] = [
     title: "Pioneer",
     homepage: "https://thirdweb-example.github.io/unity-pioneer/",
     repo: "https://github.com/thirdweb-example/unity-pioneer",
-    description: "Unity template featuring Account Abstraction, Session Keys, and Storage",
+    description:
+      "Unity template featuring Account Abstraction, Session Keys, and Storage",
     img: "/assets/templates/unity-pioneer.png",
     hoverBorderColor: "hsl(248deg 89% 79% / 15%)",
     tags: ["Unity"],

--- a/src/pages/templates.tsx
+++ b/src/pages/templates.tsx
@@ -38,9 +38,9 @@ export const templates: TemplateCardProps[] = [
   {
     id: "unity-pioneer",
     title: "Pioneer",
-    homepage: "https://thirdweb-example.github.io/unity-take-flight/",
-    repo: "https://github.com/thirdweb-example/unity-take-flight",
-    description: "Unity template with seamless onboarding experience",
+    homepage: "https://thirdweb-example.github.io/unity-pioneer/",
+    repo: "https://github.com/thirdweb-example/unity-pioneer",
+    description: "Unity template featuring Account Abstraction, Session Keys, and Storage",
     img: "/assets/templates/unity-pioneer.png",
     hoverBorderColor: "hsl(248deg 89% 79% / 15%)",
     tags: ["Unity"],
@@ -50,10 +50,10 @@ export const templates: TemplateCardProps[] = [
   {
     id: "unity-take-flight",
     title: "Take Flight",
-    homepage: "https://thirdweb-example.github.io/unity-pioneer/",
-    repo: "https://github.com/thirdweb-example/unity-pioneer",
+    homepage: "https://thirdweb-example.github.io/unity-take-flight/",
+    repo: "https://github.com/thirdweb-example/unity-take-flight",
     description:
-      "Unity template featuring Account Abstraction, Session Keys, and Storage",
+      "Unity template with Account Abstraction, Social Logins, and Onchain Scoring",
     img: "/assets/templates/unity-take-flight.png",
     hoverBorderColor: "hsl(248deg 89% 79% / 15%)",
     tags: ["Unity"],


### PR DESCRIPTION
pioneer and take-flight templates were swapped around - fixed them

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates Unity template details in `templates.tsx`. It changes the homepage and repo URLs for `Pioneer` and `Take Flight` templates, along with updating descriptions and features.

### Detailed summary
- Updated homepage and repo URLs for `Pioneer` template
- Updated description and features for `Pioneer` template
- Updated homepage and repo URLs for `Take Flight` template
- Updated description and features for `Take Flight` template

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->