### PR TITLE
Fix dynamic contract extension fieldset

### DIFF
--- a/src/components/contract-components/contract-publish-form/dynamic-contract-fieldset.tsx
+++ b/src/components/contract-components/contract-publish-form/dynamic-contract-fieldset.tsx
@@ -1,5 +1,4 @@
 import { Box, Flex, Icon } from "@chakra-ui/react";
-import { useEffect } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { FiPlus } from "react-icons/fi";
 import { Heading, Text, Button } from "tw-components";

--- a/src/components/contract-components/contract-publish-form/dynamic-contract-fieldset.tsx
+++ b/src/components/contract-components/contract-publish-form/dynamic-contract-fieldset.tsx
@@ -13,19 +13,6 @@ export const DynamicContractsFieldset = () => {
     control: form.control,
   });
 
-  useEffect(() => {
-    if (fields.length === 0) {
-      append(
-        {
-          extensionName: "",
-          extensionVersion: "",
-          publisherAddress: "",
-        },
-        { shouldFocus: false },
-      );
-    }
-  }, [fields, append, form]);
-
   return (
     <Flex gap={8} direction="column" as="fieldset">
       <Flex gap={2} direction="column">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to remove unnecessary `useEffect` hook in the `DynamicContractsFieldset` component.

### Detailed summary
- Removed `useEffect` hook that was adding default fields if none existed in the `DynamicContractsFieldset` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->