### PR TITLE
Support submission toast update

### DIFF
--- a/src/components/help/contact-support-modal.tsx
+++ b/src/components/help/contact-support-modal.tsx
@@ -36,7 +36,7 @@ export const ContactSupportModal = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const form = useForm<CreateTicketInput>();
   const { onSuccess, onError } = useTxNotifications(
-    "Successfuly sent support ticket. Our team will be in touch using your account email shortly",
+    "Successfuly sent support ticket. Our team will be in touch using your account email shortly.",
     "Failed to send ticket. Please try again.",
   );
   const { isLoggedIn } = useLoggedInUser();

--- a/src/components/help/contact-support-modal.tsx
+++ b/src/components/help/contact-support-modal.tsx
@@ -36,7 +36,7 @@ export const ContactSupportModal = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const form = useForm<CreateTicketInput>();
   const { onSuccess, onError } = useTxNotifications(
-    "Successfully sent ticket. Our team will be in touch shortly.",
+    "Successfuly sent support ticket. Our team will be in touch using your account email shortly",
     "Failed to send ticket. Please try again.",
   );
   const { isLoggedIn } = useLoggedInUser();


### PR DESCRIPTION
## Changes

- Updated toast messaging to specify where replies are sent.

## How this PR will be tested

- [ ] Visit thirdweb.com/support
- [ ] Connect your wallet and sign in
- [ ] Click on Submit a ticket 
- [ ] Click on submit on the modal 
- [ ] View the success toast message

## Output
![image](https://github.com/thirdweb-dev/dashboard/assets/160192317/ddb4b8a8-f90f-4856-af23-d69d35663995)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the success message in the contact support modal to include the user's account email for better clarity.

### Detailed summary
- Updated success message in contact support modal to include user's account email
- Changed wording from "Successfully sent ticket" to "Successfuly sent support ticket"
- Improved error message for failed ticket submission

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->