### PR TITLE
chore: adjust homepage carousel on desktop

### DIFF
--- a/src/components/partners/carousel.tsx
+++ b/src/components/partners/carousel.tsx
@@ -58,34 +58,7 @@ export const PartnerCarousel: React.FC = () => {
       pt={20}
       mb={{ base: 20, md: 24 }}
     >
-      {/* desktop - 1 row with all logos */}
-      <Marquee display={{ base: "none", lg: "flex" }}>
-        <PartnerLogo partner="coinbase" />
-        <PartnerLogo partner="polygon" />
-        <PartnerLogo partner="aws" />
-        <PartnerLogo partner="rarible" />
-        <PartnerLogo partner="treasure" />
-        <PartnerLogo partner="pixels" />
-        <PartnerLogo partner="shopify" />
-        <PartnerLogo partner="avacloud" />
-        <PartnerLogo partner="animoca" />
-        <PartnerLogo partner="mcfarlane" />
-        <PartnerLogo partner="coolcats" />
-        <PartnerLogo partner="xai" />
-        <PartnerLogo partner="courtyard" />
-        <PartnerLogo partner="aavegotchi" />
-        <PartnerLogo partner="infinigods" />
-        <PartnerLogo partner="nyfw" />
-        <PartnerLogo partner="fractal" />
-        <PartnerLogo partner="ztx" />
-        <PartnerLogo partner="torque" />
-        <PartnerLogo partner="gala_games" />
-        <PartnerLogo partner="mirror" />
-        <PartnerLogo partner="layer3" />
-      </Marquee>
-
-      {/* mobile - 2 rows with logos split in two rows */}
-      <Marquee display={{ base: "flex", lg: "none" }}>
+      <Marquee display="flex">
         <PartnerLogo partner="coinbase" />
         <PartnerLogo partner="polygon" />
         <PartnerLogo partner="aws" />
@@ -100,10 +73,7 @@ export const PartnerCarousel: React.FC = () => {
         <PartnerLogo partner="paradigm" />
       </Marquee>
 
-      <Marquee
-        animationDirection="reverse"
-        display={{ base: "flex", lg: "none" }}
-      >
+      <Marquee animationDirection="reverse" display="flex">
         <PartnerLogo partner="animoca" />
         <PartnerLogo partner="treasure" />
         <PartnerLogo partner="pixels" />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `PartnerCarousel` component in `carousel.tsx` to adjust the display of partner logos for desktop and mobile views.

### Detailed summary
- Removed the desktop layout with all logos in one row
- Updated the mobile layout to split logos into two rows
- Adjusted the display properties for better responsiveness

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->