### PR TITLE
fix: Update code-overview to use chainId instead of chain

### DIFF
--- a/src/contract-ui/tabs/code/page.tsx
+++ b/src/contract-ui/tabs/code/page.tsx
@@ -1,8 +1,7 @@
 import { CodeOverview } from "./components/code-overview";
 import { Flex } from "@chakra-ui/react";
-import { useContract, useContractType } from "@thirdweb-dev/react";
+import { useContract } from "@thirdweb-dev/react";
 import { Abi } from "@thirdweb-dev/sdk";
-import { ContractCode } from "components/contract-tabs/code/ContractCode";
 import { useEffect } from "react";
 
 interface ContractCodePageProps {
@@ -13,18 +12,12 @@ export const ContractCodePage: React.FC<ContractCodePageProps> = ({
   contractAddress,
 }) => {
   const contractQuery = useContract(contractAddress);
-  const { data: contractType, isLoading } = useContractType(contractAddress);
-
-  const usePrebuiltCodeTab =
-    contractType === "marketplace" ||
-    contractType === "pack" ||
-    contractType === "multiwrap";
 
   useEffect(() => {
     window?.scrollTo({ top: 0, behavior: "smooth" });
   }, []);
 
-  if (contractQuery.isLoading || isLoading) {
+  if (contractQuery.isLoading) {
     // TODO build a skeleton for this
     return <div>Loading...</div>;
   }
@@ -35,17 +28,10 @@ export const ContractCodePage: React.FC<ContractCodePageProps> = ({
 
   return (
     <Flex direction="column" gap={6}>
-      {usePrebuiltCodeTab ? (
-        <ContractCode
-          contractAddress={contractQuery.contract?.getAddress()}
-          contractType={contractType}
-        />
-      ) : (
-        <CodeOverview
-          abi={contractQuery.contract?.abi as Abi}
-          contractAddress={contractQuery.contract?.getAddress()}
-        />
-      )}
+      <CodeOverview
+        abi={contractQuery.contract?.abi as Abi}
+        contractAddress={contractQuery.contract?.getAddress()}
+      />
     </Flex>
   );
 };

--- a/src/pages/[chainSlug]/index.tsx
+++ b/src/pages/[chainSlug]/index.tsx
@@ -499,7 +499,7 @@ const ChainPage: ThirdwebNextPage = ({
         {!isDeprecated && (
           <>
             <Divider />
-            <CodeOverview onlyInstall chain={chain} noSidebar />
+            <CodeOverview onlyInstall chainId={chain.chainId} noSidebar />
           </>
         )}
       </Container>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
**Focus:** Refactoring contract UI components for better readability and maintainability.

### Detailed summary
- Updated `CodeOverview` component to use `chainId` instead of `chain` for clarity.
- Removed unnecessary imports and unused variables.
- Simplified logic in `ContractCodePage` component for loading state handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->