### PR TITLE
fix import in landing code snippets

### DIFF
--- a/src/contract-ui/tabs/code/components/code-overview.tsx
+++ b/src/contract-ui/tabs/code/components/code-overview.tsx
@@ -179,7 +179,7 @@ const { transactionHash } = await sendTransaction({
   account 
 })`,
     react: `import { prepareContractCall, resolveMethod } from "thirdweb"
-import { useSendTransaction } from "@thirdweb-dev/react";
+import { useSendTransaction } from "thirdweb/react";
 
 export default function Component() {
   const { mutate: sendTransaction, isLoading, isError } = useSendTransaction();
@@ -194,7 +194,7 @@ export default function Component() {
   }
 }`,
     "react-native": `import { prepareContractCall } from "thirdweb"
-import { useSendTransaction } from "@thirdweb-dev/react";
+import { useSendTransaction } from "thirdweb/react";
     
 export default function Component() {
   const { mutate: sendTransaction, isLoading, isError } = useSendTransaction();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the import path for `useSendTransaction` in React and React Native components to use the correct path from "thirdweb/react".

### Detailed summary
- Updated import path for `useSendTransaction` in React component to "thirdweb/react"
- Updated import path for `useSendTransaction` in React Native component to "thirdweb/react"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->