### PR TITLE
Make chainlist page faster

### DIFF
--- a/src/hooks/useShowMore.ts
+++ b/src/hooks/useShowMore.ts
@@ -1,26 +1,40 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 export function useShowMore<T extends HTMLElement>(
   initialItemsToShow: number,
   itemsToAdd: number,
 ) {
   const [itemsToShow, setItemsToShow] = useState(initialItemsToShow);
+  const prevNode = useRef<T | null>(null);
+
+  const observer = useMemo(() => {
+    // server
+    if (typeof IntersectionObserver === "undefined") {
+      return undefined;
+    }
+
+    return new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setItemsToShow((prev) => prev + itemsToAdd);
+        }
+      },
+      { threshold: 1 },
+    );
+  }, []);
+
   const lastItemRef = useCallback(
     (node: T) => {
       if (!node) {
         return;
       }
 
-      const observer = new IntersectionObserver(
-        (entries) => {
-          if (entries[0]?.isIntersecting) {
-            setItemsToShow((prev) => prev + itemsToAdd);
-          }
-        },
-        { threshold: 1 },
-      );
+      if (prevNode.current) {
+        observer?.unobserve(prevNode.current);
+      }
 
-      observer.observe(node);
+      observer?.observe(node);
+      prevNode.current = node;
     },
     [itemsToAdd],
   );

--- a/src/hooks/useShowMore.ts
+++ b/src/hooks/useShowMore.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+
+export function useShowMore<T extends HTMLElement>(
+  initialItemsToShow: number,
+  itemsToAdd: number,
+) {
+  const [itemsToShow, setItemsToShow] = useState(initialItemsToShow);
+  const lastItemRef = useCallback(
+    (node: T) => {
+      if (!node) {
+        return;
+      }
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            setItemsToShow((prev) => prev + itemsToAdd);
+          }
+        },
+        { threshold: 1 },
+      );
+
+      observer.observe(node);
+    },
+    [itemsToAdd],
+  );
+
+  return { itemsToShow, lastItemRef };
+}

--- a/src/hooks/useShowMore.ts
+++ b/src/hooks/useShowMore.ts
@@ -21,7 +21,7 @@ export function useShowMore<T extends HTMLElement>(
       },
       { threshold: 1 },
     );
-  }, []);
+  }, [itemsToAdd]);
 
   const lastItemRef = useCallback(
     (node: T) => {
@@ -36,7 +36,7 @@ export function useShowMore<T extends HTMLElement>(
       observer?.observe(node);
       prevNode.current = node;
     },
-    [itemsToAdd],
+    [observer],
   );
 
   return { itemsToShow, lastItemRef };

--- a/src/pages/chainlist.tsx
+++ b/src/pages/chainlist.tsx
@@ -10,8 +10,10 @@ import {
   InputRightElement,
   LinkBox,
   LinkOverlay,
+  ListItem,
   SimpleGrid,
   Spinner,
+  UnorderedList,
   useColorMode,
 } from "@chakra-ui/react";
 import type { Chain } from "@thirdweb-dev/chains";
@@ -32,6 +34,7 @@ import {
   TrackedLink,
 } from "tw-components";
 import { ThirdwebNextPage } from "utils/types";
+import { useShowMore } from "../hooks/useShowMore";
 
 const TRACKING_CATEGORY = "chains";
 
@@ -208,12 +211,24 @@ export const PublishUpsellCard: React.FC = () => {
 export const SearchResults: React.FC<{
   chains: MinimalRPCChain[];
 }> = memo(function SearchResults(props) {
+  const { itemsToShow, lastItemRef } = useShowMore<HTMLLIElement>(15, 9);
+
+  const resultsToShow = props.chains.slice(0, itemsToShow);
+
   return (
-    <SimpleGrid columns={{ base: 1, md: 3 }} gap={6}>
-      {props.chains.map((chain) => (
-        <SearchResult chain={chain} key={`chain_${chain.chainId}`} />
-      ))}
-    </SimpleGrid>
+    <UnorderedList display="block" p={0} m={0}>
+      <SimpleGrid columns={{ base: 1, md: 3 }} gap={6}>
+        {resultsToShow.map((chain, i) => (
+          <ListItem
+            ref={i === resultsToShow.length - 1 ? lastItemRef : undefined}
+            listStyleType={"none"}
+            key={chain.chainId}
+          >
+            <SearchResult chain={chain} />
+          </ListItem>
+        ))}
+      </SimpleGrid>
+    </UnorderedList>
   );
 });
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to implement a `useShowMore` custom hook that dynamically loads more items when scrolling. 

### Detailed summary
- Added `useShowMore` custom hook in `useShowMore.ts`
- Utilized `useShowMore` in `chainlist.tsx` to show more search results dynamically as the user scrolls

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->