### PR TITLE
Fix: Billing page in settings not showing growth plan trial

### DIFF
--- a/src/components/settings/Account/Billing/index.tsx
+++ b/src/components/settings/Account/Billing/index.tsx
@@ -254,7 +254,7 @@ export const Billing: React.FC<BillingProps> = ({ account }) => {
       <BillingPricing
         plan={account.plan}
         trialPeriodEndedAt={account.trialPeriodEndedAt}
-        canTrialGrowth={!!account.trialPeriodEndedAt}
+        canTrialGrowth={account.trialPeriodEndedAt ? false : true}
         validPayment={validPayment}
         paymentVerification={paymentVerification}
         invalidPayment={invalidPayment}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the logic for determining if trial growth is allowed in the Billing component.

### Detailed summary
- Updated logic for `canTrialGrowth` to check if `trialPeriodEndedAt` is truthy instead of falsy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->