### PR TITLE
feat: Add activeTrialEndsAt prop to PricingCard

### DIFF
--- a/src/components/homepage/sections/PricingCard.tsx
+++ b/src/components/homepage/sections/PricingCard.tsx
@@ -90,11 +90,21 @@ export const PricingCard: React.FC<PricingCardProps> = ({
             <Heading
               size={size === "lg" ? "title.2xl" : "title.md"}
               lineHeight={1}
-              textDecor={canTrialGrowth ? "line-through" : "none"}
             >
-              {!isCustomPrice && "$"}
-              {plan.price}
+              {isCustomPrice ? (
+                plan.price
+              ) : canTrialGrowth ? (
+                <>
+                  <Box as="span" textDecor="line-through" opacity={0.4}>
+                    ${plan.price}
+                  </Box>{" "}
+                  $0
+                </>
+              ) : (
+                `$${plan.price}`
+              )}
             </Heading>
+
             {!isCustomPrice && <Text size="body.lg">/ month</Text>}
           </Flex>
           {remainingTrialDays > 0 && (

--- a/src/components/homepage/sections/PricingCard.tsx
+++ b/src/components/homepage/sections/PricingCard.tsx
@@ -11,6 +11,7 @@ import { PLANS } from "utils/pricing";
 import { AccountPlan } from "@3rdweb-sdk/react/hooks/useApi";
 import { FeatureItem } from "./FeatureItem";
 import { UpgradeModal } from "./UpgradeModal";
+import { remainingDays } from "../../../utils/date-utils";
 
 interface PricingCardProps {
   name: AccountPlan;
@@ -23,6 +24,7 @@ interface PricingCardProps {
   current?: boolean;
   canTrialGrowth?: boolean;
   size?: "sm" | "lg";
+  activeTrialEndsAt?: string;
 }
 
 export const PricingCard: React.FC<PricingCardProps> = ({
@@ -36,9 +38,13 @@ export const PricingCard: React.FC<PricingCardProps> = ({
   highlighted = false,
   current = false,
   canTrialGrowth = false,
+  activeTrialEndsAt,
 }) => {
   const plan = PLANS[name];
   const isCustomPrice = typeof plan.price === "string";
+
+  const remainingTrialDays =
+    (activeTrialEndsAt ? remainingDays(activeTrialEndsAt) : 0) || 0;
 
   const content = (
     <Card
@@ -79,16 +85,26 @@ export const PricingCard: React.FC<PricingCardProps> = ({
             {plan.description}
           </Text>
         </Flex>
-        <Flex alignItems={{ base: "center", md: "flex-end" }} gap={2}>
-          <Heading
-            size={size === "lg" ? "title.2xl" : "title.md"}
-            lineHeight={1}
-            textDecor={canTrialGrowth ? "line-through" : "none"}
-          >
-            {!isCustomPrice && "$"}
-            {plan.price}
-          </Heading>
-          {!isCustomPrice && <Text size="body.lg">/ month</Text>}
+        <Flex direction="column" gap={0.5}>
+          <Flex alignItems={{ base: "center", md: "flex-end" }} gap={2}>
+            <Heading
+              size={size === "lg" ? "title.2xl" : "title.md"}
+              lineHeight={1}
+              textDecor={canTrialGrowth ? "line-through" : "none"}
+            >
+              {!isCustomPrice && "$"}
+              {plan.price}
+            </Heading>
+            {!isCustomPrice && <Text size="body.lg">/ month</Text>}
+          </Flex>
+          {remainingTrialDays > 0 && (
+            <Text size="body.sm" fontStyle="italic">
+              Your free trial will{" "}
+              {remainingTrialDays > 1
+                ? `end in ${remainingTrialDays} days.`
+                : "end today."}
+            </Text>
+          )}
         </Flex>
       </Flex>
       <Flex
@@ -119,26 +135,28 @@ export const PricingCard: React.FC<PricingCardProps> = ({
       ) : (
         <Flex flexDir="column" gap={3} position="relative" mb={3}>
           {ctaTitle && (
-            <TrackedLinkButton
-              variant="outline"
-              py={6}
-              label={ctaProps.label ?? name}
-              size={size === "lg" ? "md" : "sm"}
-              {...ctaProps}
-            >
-              {ctaTitle}
-            </TrackedLinkButton>
-          )}
-          {ctaHint && (
-            <Text
-              textAlign="center"
-              size="body.sm"
-              w="full"
-              position={{ base: "static", xl: "absolute" }}
-              top={ctaTitle ? 14 : -9}
-            >
-              {ctaHint}
-            </Text>
+            <>
+              <TrackedLinkButton
+                variant="outline"
+                py={6}
+                label={ctaProps.label ?? name}
+                size={size === "lg" ? "md" : "sm"}
+                {...ctaProps}
+              >
+                {ctaTitle}
+              </TrackedLinkButton>
+              {ctaHint && (
+                <Text
+                  textAlign="center"
+                  size="body.sm"
+                  w="full"
+                  position={{ base: "static", xl: "absolute" }}
+                  top={ctaTitle ? 14 : -9}
+                >
+                  {ctaHint}
+                </Text>
+              )}
+            </>
           )}
         </Flex>
       )}
@@ -147,7 +165,7 @@ export const PricingCard: React.FC<PricingCardProps> = ({
 
   if (highlighted) {
     return (
-      <Center position="relative" p={0.5} mt={-0.5} mb={-0.5}>
+      <Center position="relative" p={2} m={-2}>
         <Box
           position="absolute"
           bgGradient="linear(to-b, #4DABEE, #692AC1)"

--- a/src/components/homepage/sections/PricingSection.tsx
+++ b/src/components/homepage/sections/PricingSection.tsx
@@ -64,7 +64,7 @@ export const PricingSection: React.FC<PricingSectionProps> = ({
             name={AccountPlan.Growth}
             ctaHint={
               canTrialGrowth
-                ? `Your free trial will end in 30 days.`
+                ? `Your free trial will end after 30 days.`
                 : undefined
             }
             canTrialGrowth={canTrialGrowth}

--- a/src/components/onboarding/ChoosePlan.tsx
+++ b/src/components/onboarding/ChoosePlan.tsx
@@ -92,7 +92,7 @@ export const OnboardingChoosePlan: React.FC<OnboardingChoosePlanProps> = ({
           size="sm"
           ctaTitle={"Claim your 1-month free"}
           name={AccountPlan.Growth}
-          ctaHint={`Your free trial will end in 30 days.`}
+          ctaHint="Your free trial will end after 30 days."
           canTrialGrowth={true}
           ctaProps={{
             category: "account",

--- a/src/components/settings/Account/Billing/Pricing.tsx
+++ b/src/components/settings/Account/Billing/Pricing.tsx
@@ -3,7 +3,6 @@ import { AccountPlan } from "@3rdweb-sdk/react/hooks/useApi";
 import { PricingCard } from "components/homepage/sections/PricingCard";
 import { useMemo } from "react";
 import { CONTACT_US_URL } from "utils/pricing";
-import { remainingDays } from "utils/date-utils";
 
 interface BillingPricingProps {
   plan: string;
@@ -37,6 +36,8 @@ export const BillingPricing: React.FC<BillingPricingProps> = ({
     if (plan !== AccountPlan.Free) {
       return "Downgrade";
     }
+
+    return undefined;
   }, [plan, validPayment]);
 
   const growthCtaTitle = useMemo(() => {
@@ -53,26 +54,9 @@ export const BillingPricing: React.FC<BillingPricingProps> = ({
     if (plan === AccountPlan.Free) {
       return canTrialGrowth ? trialTitle : "Upgrade";
     }
+
+    return undefined;
   }, [validPayment, isPro, plan, canTrialGrowth]);
-
-  const trialPeriodDays = useMemo(() => {
-    let days = undefined;
-
-    // can trial growth and not pro
-    if (canTrialGrowth && !isPro) {
-      days = 30;
-    }
-    // already has trial period
-    else if (trialPeriodEndedAt && plan === AccountPlan.Growth) {
-      days = remainingDays(trialPeriodEndedAt);
-    }
-
-    if (!days) {
-      return undefined;
-    }
-
-    return `Your free trial will end in ${days} days.`;
-  }, [canTrialGrowth, isPro, plan, trialPeriodEndedAt]);
 
   const handleSelect = (newPlan: AccountPlan) => {
     onSelect(newPlan);
@@ -100,11 +84,14 @@ export const BillingPricing: React.FC<BillingPricingProps> = ({
       />
 
       <PricingCard
+        activeTrialEndsAt={
+          plan === AccountPlan.Growth ? trialPeriodEndedAt : undefined
+        }
         current={plan === AccountPlan.Growth}
         size="sm"
         name={AccountPlan.Growth}
         ctaTitle={growthCtaTitle}
-        ctaHint={trialPeriodDays}
+        ctaHint="Your free trial will end after 30 days."
         canTrialGrowth={canTrialGrowth}
         ctaProps={{
           onClick: (e) => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the messaging related to free trial periods across different components.

### Detailed summary
- Updated messaging from "Your free trial will end in 30 days" to "Your free trial will end after 30 days" for consistency.
- Removed unnecessary code related to trial period days calculations.
- Added a new prop `activeTrialEndsAt` to track the end date of the active trial period.
- Improved the display of remaining trial days on the pricing card.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->