### PR TITLE
fix: Fix v4 contract metadata update and invalidate

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -125,6 +125,7 @@ const moduleExports = {
     instrumentationHook: true,
     scrollRestoration: true,
     esmExternals: "loose",
+    webpackBuildWorker: true,
   },
   compiler: {
     emotion: true,

--- a/src/hooks/invalidate-v4-contract.ts
+++ b/src/hooks/invalidate-v4-contract.ts
@@ -1,0 +1,17 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { invalidateContractAndBalances } from "@thirdweb-dev/react";
+
+/**
+ * @internal
+ */
+export function useInvalidatev4Contract() {
+  const queryClient = useQueryClient();
+
+  return ({
+    chainId,
+    contractAddress,
+  }: {
+    chainId: number;
+    contractAddress: string;
+  }) => invalidateContractAndBalances(queryClient, contractAddress, chainId);
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to introduce a new `webpackBuildWorker` option in `next.config.js` and adapt components to use v5 features and APIs.

### Detailed summary
- Added `webpackBuildWorker` option in `next.config.js`
- Introduced `useInvalidatev4Contract` hook for v4 contract invalidation
- Updated components to use v5 features and APIs such as `useDisconnect` and `useSetActiveWallet`
- Implemented `V4ToV5SignerAdapter` for transitioning signers to v5
- Utilized `useSendAndConfirmTransaction` for sending and confirming transactions
- Updated metadata settings component to work with v5 contracts and clients

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->