### PR TITLE
polish: Engine pricing cards, deploy confirmation modal

### DIFF
--- a/src/components/homepage/sections/PricingEngine.tsx
+++ b/src/components/homepage/sections/PricingEngine.tsx
@@ -43,8 +43,6 @@ export const PricingEngineHomepage: React.FC<PricingSectionProps> = ({
               "On-call monitoring from thirdweb",
             ]}
             ctaText="Get Started"
-            // empty to override the default cta hint
-            ctaHint=" "
             onClick={() => {
               track({
                 category: trackingCategory,
@@ -69,8 +67,6 @@ export const PricingEngineHomepage: React.FC<PricingSectionProps> = ({
             ]}
             isPrimaryCta
             ctaText="Get Started"
-            // empty to override the default cta hint
-            ctaHint=" "
             onClick={() => {
               track({
                 category: trackingCategory,
@@ -91,8 +87,6 @@ export const PricingEngineHomepage: React.FC<PricingSectionProps> = ({
               "Custom deployment",
               "Priority support",
             ]}
-            // empty to override the default cta hint
-            ctaHint=" "
             onClick={() => {
               track({
                 category: trackingCategory,

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -205,11 +205,15 @@ const Pricing: ThirdwebNextPage = () => {
         </Flex>
 
         <Flex gap={4} flexDir="column" alignItems="center">
-          <Heading size="title.xl" color="white">
+          <Heading as="h2" size="title.xl" color="white">
             Add-ons
           </Heading>
-
-          <EnginePricing />
+          <Flex flexDir="column" gap={0}>
+            <Heading as="h3" size="subtitle.lg">
+              Engine
+            </Heading>
+            <EnginePricing />
+          </Flex>
         </Flex>
 
         <Flex gap={4} flexDir="column" alignItems="center">

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -10,7 +10,14 @@ import {
 } from "@chakra-ui/react";
 import { LandingLayout } from "components/landing-pages/layout";
 import { PageId } from "page-id";
-import { Card, Heading, Link, Text, TrackedIconButton } from "tw-components";
+import {
+  Card,
+  Heading,
+  Link,
+  Text,
+  TrackedIconButton,
+  TrackedLink,
+} from "tw-components";
 import { ThirdwebNextPage } from "utils/types";
 import { IoCheckmarkCircle } from "react-icons/io5";
 import { AiOutlineDollarCircle } from "react-icons/ai";
@@ -20,6 +27,9 @@ import { PricingSection } from "components/homepage/sections/PricingSection";
 import { FAQ_GENERAL, FAQ_PRICING, PRICING_SECTIONS } from "utils/pricing";
 import { IoIosInformationCircleOutline } from "react-icons/io";
 import { FiExternalLink } from "react-icons/fi";
+import { EngineTierCard } from "components/engine/create-engine-instance";
+import { useTrack } from "hooks/analytics/useTrack";
+import { useRouter } from "next/router";
 
 const TRACKING_CATEGORY = "pricing-page";
 
@@ -193,6 +203,15 @@ const Pricing: ThirdwebNextPage = () => {
             </Flex>
           ))}
         </Flex>
+
+        <Flex gap={4} flexDir="column" alignItems="center">
+          <Heading size="title.xl" color="white">
+            Add-ons
+          </Heading>
+
+          <EnginePricing />
+        </Flex>
+
         <Flex gap={4} flexDir="column" alignItems="center">
           <Heading size="title.xl" color="white">
             FAQ
@@ -304,6 +323,97 @@ const Item = ({
         )}
       </Flex>
     </Card>
+  );
+};
+
+const EnginePricing = () => {
+  const track = useTrack();
+  const router = useRouter();
+
+  return (
+    <Flex flexDir="column" gap={4} w="full">
+      <Text>
+        Host Engine on thirdweb with no setup or maintenance required.{" "}
+        <TrackedLink
+          href="https://portal.thirdweb.com/engine"
+          isExternal
+          color="blue.500"
+          fontSize="small"
+          category={TRACKING_CATEGORY}
+          label="clicked-docs"
+        >
+          Learn more about Engine &rarr;
+        </TrackedLink>
+      </Text>
+      <SimpleGrid columns={{ base: 1, lg: 3 }} gap={6}>
+        <EngineTierCard
+          iconSrc={require("../../public/assets/engine/cloud-icon1.png")}
+          tier="Standard Engine"
+          monthlyPrice={99}
+          features={[
+            "Isolated server & database",
+            "APIs for contracts on all EVM chains",
+            "Secure backend wallets",
+            "Automated gas & nonce management",
+            "On-call monitoring from thirdweb",
+          ]}
+          ctaText="Get Started"
+          onClick={() => {
+            track({
+              category: TRACKING_CATEGORY,
+              action: "click",
+              label: "clicked-cloud-hosted",
+              tier: "STANDARD",
+            });
+            router.push("/dashboard/engine");
+          }}
+        />
+
+        <EngineTierCard
+          iconSrc={require("../../public/assets/engine/cloud-icon2.png")}
+          tier="Premium Engine"
+          previousTier="Standard Engine"
+          monthlyPrice={299}
+          features={[
+            "Autoscaling",
+            "Server failover",
+            "Database failover",
+            "30-day database backups",
+          ]}
+          isPrimaryCta
+          ctaText="Get Started"
+          onClick={() => {
+            track({
+              category: TRACKING_CATEGORY,
+              action: "click",
+              label: "clicked-cloud-hosted",
+              tier: "PREMIUM",
+            });
+            router.push("/dashboard/engine");
+          }}
+        />
+
+        <EngineTierCard
+          iconSrc={require("../../public/assets/engine/cloud-icon3.png")}
+          tier="Enterprise Engine"
+          previousTier="Premium Engine"
+          features={[
+            "Custom features",
+            "Custom deployment",
+            "Priority support",
+          ]}
+          onClick={() => {
+            track({
+              category: TRACKING_CATEGORY,
+              action: "click",
+              label: "clicked-cloud-hosted",
+              tier: "ENTERPRISE",
+            });
+            router.push("/contact-us");
+          }}
+        />
+      </SimpleGrid>
+    </Flex>
   );
 };
 

--- a/src/utils/pricing.tsx
+++ b/src/utils/pricing.tsx
@@ -167,18 +167,6 @@ export const PRICING_SECTIONS: PricingSection[] = [
       },
     ],
   },
-  {
-    title: "Add-ons:",
-    items: [
-      {
-        title: "Engine: Cloud-hosted instance",
-        learnMore: "/engine",
-        starter: "$99/month",
-        growth: "$99/month",
-        pro: "Custom",
-      },
-    ],
-  },
 ];
 
 export const FAQ_GENERAL = [


### PR DESCRIPTION
Pricing page
<img width="1232" alt="image" src="https://github.com/thirdweb-dev/dashboard/assets/7673418/60f4d952-3bb1-4c83-973a-78a43b79aaf8">


Get cloud hosted Engine modal
<img width="1190" alt="image" src="https://github.com/thirdweb-dev/dashboard/assets/7673418/04de3063-ff04-44d5-9bd9-c1d566eb874d">


Confirmation step
<img width="574" alt="image" src="https://github.com/thirdweb-dev/dashboard/assets/7673418/7fe10409-e5db-4dcd-adb6-a5b2240142db">



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates pricing components and engine deployment options. 

### Detailed summary
- Added `EnginePricing` component to display engine tiers and features
- Updated `CreateCloudHostedEngineModal` to confirm tier selection before deployment
- Added `ModalFooter` in `CreateCloudHostedEngineModal` for tier confirmation actions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->