### PR TITLE
chore: support split native currency for all chains

### DIFF
--- a/src/pages/api/moralis/balances.ts
+++ b/src/pages/api/moralis/balances.ts
@@ -1,7 +1,9 @@
 import { SUPPORTED_CHAIN_ID } from "@thirdweb-dev/sdk";
-import { CURRENCIES } from "constants/currencies";
 import { constants, utils } from "ethers";
+import { thirdwebClient } from "lib/thirdweb-client";
 import { NextApiRequest, NextApiResponse } from "next";
+import { defineChain } from "thirdweb";
+import { getWalletBalance } from "thirdweb/wallets";
 
 export type BalanceQueryRequest = {
   chainId: SUPPORTED_CHAIN_ID;
@@ -27,58 +29,55 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(400).json({ error: "invalid address" });
   }
 
-  const _chain = encodeURIComponent(`0x${chainId?.toString(16)}`);
-  const _address = encodeURIComponent(address);
+  const getNativeBalance = async (): Promise<BalanceQueryResponse> => {
+    const chain = defineChain(chainId);
+    const balance = await getWalletBalance({
+      address,
+      chain,
+      client: thirdwebClient,
+    });
+    return [
+      {
+        token_address: constants.AddressZero,
+        symbol: balance.symbol,
+        name: "Native Token",
+        decimals: balance.decimals,
+        balance: balance.value.toString(),
+        display_balance: balance.displayValue,
+      },
+    ];
+  };
 
-  const tokenBalanceEndpoint = `https://deep-index.moralis.io/api/v2/${_address}/erc20?chain=${_chain}`;
-  const nativeBalanceEndpoint = `https://deep-index.moralis.io/api/v2/${_address}/balance?chain=${_chain}`;
+  const getERC20Balances = async (): Promise<BalanceQueryResponse> => {
+    const _chain = encodeURIComponent(`0x${chainId?.toString(16)}`);
+    const _address = encodeURIComponent(address);
+    const tokenBalanceEndpoint = `https://deep-index.moralis.io/api/v2/${_address}/erc20?chain=${_chain}`;
+
+    const resp = await fetch(tokenBalanceEndpoint, {
+      method: "GET",
+      headers: {
+        "x-api-key": process.env.MORALIS_API_KEY || "",
+      },
+    });
+    if (!resp.ok) {
+      resp.body?.cancel();
+      return [];
+    }
+    const json = await resp.json();
+    return json.map((balance: any) => ({
+      ...balance,
+      display_balance: utils
+        .formatUnits(balance.balance, balance.decimals)
+        .toString(),
+    }));
+  };
 
   const [nativeBalance, tokenBalances] = await Promise.all([
-    fetch(nativeBalanceEndpoint, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": process.env.MORALIS_API_KEY || "",
-      },
-    }).then((nRes) => nRes.json()),
-    fetch(tokenBalanceEndpoint, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": process.env.MORALIS_API_KEY || "",
-      },
-    }).then((tRes) => tRes.json()),
+    getNativeBalance(),
+    getERC20Balances(),
   ]);
 
-  const native = CURRENCIES[chainId]?.find(
-    (c) => c.address === constants.AddressZero,
-  );
-
-  if (tokenBalances?.message) {
-    return res.status(400).json({ error: tokenBalances.message });
-  }
-
-  if (nativeBalance?.message) {
-    return res.status(400).json({ error: nativeBalance.message });
-  }
-
-  const balances = [
-    ...(tokenBalances || []),
-    {
-      token_address: native?.address,
-      symbol: native?.symbol,
-      name: "Native Token",
-      decimals: 18,
-      balance: nativeBalance.balance,
-    },
-  ].map((balance) => ({
-    ...balance,
-    display_balance: utils
-      .formatUnits(balance.balance, balance.decimals)
-      .toString(),
-  }));
-
-  return res.status(200).json(balances);
+  return res.status(200).json([...nativeBalance, ...tokenBalances]);
 };
 
 export default handler;

--- a/src/pages/api/moralis/balances.ts
+++ b/src/pages/api/moralis/balances.ts
@@ -48,7 +48,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     ];
   };
 
-  const getERC20Balances = async (): Promise<BalanceQueryResponse> => {
+  const getTokenBalances = async (): Promise<BalanceQueryResponse> => {
     const _chain = encodeURIComponent(`0x${chainId?.toString(16)}`);
     const _address = encodeURIComponent(address);
     const tokenBalanceEndpoint = `https://deep-index.moralis.io/api/v2/${_address}/erc20?chain=${_chain}`;
@@ -74,7 +74,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const [nativeBalance, tokenBalances] = await Promise.all([
     getNativeBalance(),
-    getERC20Balances(),
+    getTokenBalances(),
   ]);
 
   return res.status(200).json([...nativeBalance, ...tokenBalances]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the API handler to fetch wallet balances using a third-party API and improve data processing for native and token balances.

### Detailed summary
- Removed unused import of `CURRENCIES`
- Added imports for `thirdwebClient`, `defineChain`, and `getWalletBalance`
- Refactored balance retrieval logic into `getNativeBalance` and `getTokenBalances` functions
- Updated endpoint URLs for fetching token balances
- Improved error handling for API responses
- Reorganized balance retrieval and processing logic
- Updated response format to return combined native and token balances

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->