### PR TITLE
changes for thirdweb Pay launch

### DIFF
--- a/src/components/notices/AnnouncementBanner.tsx
+++ b/src/components/notices/AnnouncementBanner.tsx
@@ -5,7 +5,7 @@ import { Heading, TrackedLink } from "tw-components";
 
 export const AnnouncementBanner = () => {
   const [hasDismissedAnnouncement, setHasDismissedAnnouncement] =
-    useLocalStorage("dismissed-op-superchain", false, true);
+    useLocalStorage("dismissed-thirdweb-pay", false, true);
 
   if (hasDismissedAnnouncement) {
     return null;
@@ -27,9 +27,9 @@ export const AnnouncementBanner = () => {
       >
         <Box display={{ base: "none", md: "block" }} />
         <TrackedLink
-          href="https://grtlfwnv13r.typeform.com/to/FTzFOPM2"
+          href="https://pay-demo.thirdweb.com/"
           category="announcement"
-          label="chain-request"
+          label="thirdweb-pay"
         >
           <Container maxW="container.page" display="flex" px={0}>
             <Flex
@@ -46,8 +46,8 @@ export const AnnouncementBanner = () => {
                 color="white"
                 fontWeight={500}
               >
-                Don&apos;t see your preferred chain on thirdweb? Request to have
-                any chain added to our full stack web3 development kit.
+                Introducing thirdweb Pay: Onramp users to your app with credit
+                card & cross-chain crypto. Integrate for free
               </Heading>
               <Icon display={{ base: "none", md: "block" }} as={FiArrowRight} />
             </Flex>

--- a/src/pages/connect.tsx
+++ b/src/pages/connect.tsx
@@ -292,9 +292,9 @@ const ConnectLanding: ThirdwebNextPage = () => {
             miniImage={require("../../public/assets/product-pages/connect/icon-pay.png")}
             title="Fiat & cross-chain crypto payments,"
             titleWithGradient="made easy"
-            subtitle="The easiest way for users to transact in your app — with automatic bridging & swapping built in."
+            subtitle="The easiest way for users to onramp to your app — with credit card & cross-chain crypto payments."
             trackingCategory={TRACKING_CATEGORY}
-            ctaLink="https://portal.thirdweb.com/connect/pay/buy-with-crypto"
+            ctaLink="https://portal.thirdweb.com/connect/pay/overview"
             gradient="linear(to-r, #4490FF, #4490FF)"
             image={require("../../public/assets/product-pages/hero/desktop-pay.png")}
             mobileImage={require("../../public/assets/product-pages/hero/mobile-pay.png")}

--- a/src/pages/connect.tsx
+++ b/src/pages/connect.tsx
@@ -292,7 +292,7 @@ const ConnectLanding: ThirdwebNextPage = () => {
             miniImage={require("../../public/assets/product-pages/connect/icon-pay.png")}
             title="Fiat & cross-chain crypto payments,"
             titleWithGradient="made easy"
-            subtitle="The easiest way for users to onramp to your app — with credit card & cross-chain crypto payments."
+            subtitle="The easiest way for users to transact in your app — with credit card & cross-chain crypto payments."
             trackingCategory={TRACKING_CATEGORY}
             ctaLink="https://portal.thirdweb.com/connect/pay/overview"
             gradient="linear(to-r, #4490FF, #4490FF)"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `Connect` page with new subtitle text and CTA link, and rename the AnnouncementBanner component to `thirdweb Pay`.

### Detailed summary
- Updated `Connect` page subtitle and CTA link for credit card & cross-chain crypto payments.
- Renamed AnnouncementBanner to `thirdweb Pay`.
- Changed AnnouncementBanner content to promote thirdweb Pay onramp service.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->