### PR TITLE
Fix: Do not pass from on read functions

### DIFF
--- a/src/components/contract-functions/interactive-abi-function.tsx
+++ b/src/components/contract-functions/interactive-abi-function.tsx
@@ -177,7 +177,7 @@ export const InteractiveAbiFunction: React.FC<InteractiveAbiFunctionProps> = ({
       (abiFunction?.stateMutability === "view" ||
         abiFunction?.stateMutability === "pure")
     ) {
-      readFn({ args: [], overrides: { from: connectedWalletAddress } });
+      readFn({ args: [] });
     }
   }, [readFn, abiFunction?.stateMutability, form, connectedWalletAddress]);
 
@@ -213,7 +213,6 @@ export const InteractiveAbiFunction: React.FC<InteractiveAbiFunctionProps> = ({
               ) {
                 readFn({
                   args: formatted,
-                  overrides: { from: connectedWalletAddress },
                 });
               } else {
                 mutate({


### PR DESCRIPTION
Certain RPCs will attempt to simulate a transaction if you pass a `from` address with `eth_call`. This removes all from addresses from calls in the contract explorer.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to remove the `overrides` property from the `readFn` function call when `abiFunction` state mutability is "pure".

### Detailed summary
- Removed `overrides` property from `readFn` function call when `abiFunction` state mutability is "pure".
- Code cleanup and optimization.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->