### PR TITLE
Updated Dashboard back to use Starter

### DIFF
--- a/src/@3rdweb-sdk/react/hooks/useEngine.ts
+++ b/src/@3rdweb-sdk/react/hooks/useEngine.ts
@@ -14,7 +14,7 @@ export function useEngineConnectedInstance() {
   return { instance, setInstance };
 }
 
-export type EngineTier = "STANDARD" | "PREMIUM" | "ENTERPRISE";
+export type EngineTier = "STARTER" | "PREMIUM" | "ENTERPRISE";
 
 // Engine instances
 export type EngineInstance = {

--- a/src/components/engine/create-engine-instance.tsx
+++ b/src/components/engine/create-engine-instance.tsx
@@ -42,7 +42,7 @@ export const CreateEngineInstanceButton = ({
   const trackEvent = useTrack();
   const toast = useToast();
   const accountQuery = useAccount();
-  const [engineTier, setEngineTier] = useState<EngineTier>("STANDARD");
+  const [engineTier, setEngineTier] = useState<EngineTier>("STARTER");
 
   const addCloudHostedEngine = async (tier?: EngineTier) => {
     trackEvent({
@@ -163,7 +163,7 @@ const CreateCloudHostedEngineModal = ({
 
   if (modalState === "confirmStandard" || modalState === "confirmPremium") {
     const tier: EngineTier =
-      modalState === "confirmStandard" ? "STANDARD" : "PREMIUM";
+      modalState === "confirmStandard" ? "STARTER" : "PREMIUM";
 
     return (
       <Modal
@@ -183,7 +183,7 @@ const CreateCloudHostedEngineModal = ({
             />
             <Heading size="title.sm">
               Are you sure you want to deploy a{" "}
-              {tier === "STANDARD" ? "Standard" : "Premium"} Engine?
+              {tier === "STARTER" ? "Standard" : "Premium"} Engine?
             </Heading>
             <Text>
               You will be charged ${MONTHLY_PRICE_USD[tier]} per month for the
@@ -222,7 +222,7 @@ const CreateCloudHostedEngineModal = ({
           </Text>
           <SimpleGrid columns={{ base: 1, lg: 3 }} gap={6}>
             <EngineTierCard
-              tier="STANDARD"
+              tier="STARTER"
               onClick={() => setModalState("confirmStandard")}
             />
 

--- a/src/components/engine/tier-card.tsx
+++ b/src/components/engine/tier-card.tsx
@@ -10,7 +10,7 @@ interface EngineTierCardConfig {
 }
 
 const ENGINE_TIER_CARD_CONFIG: Record<EngineTier, EngineTierCardConfig> = {
-  STANDARD: {
+  STARTER: {
     name: "Standard",
     monthlyPriceUsd: 99,
     features: [
@@ -39,7 +39,7 @@ const ENGINE_TIER_CARD_CONFIG: Record<EngineTier, EngineTierCardConfig> = {
 };
 
 export const MONTHLY_PRICE_USD: Record<EngineTier, number> = {
-  STANDARD: 99,
+  STARTER: 99,
   PREMIUM: 299,
   ENTERPRISE: 0,
 };
@@ -60,7 +60,7 @@ export const EngineTierCard = ({
   const { name, monthlyPriceUsd } = ENGINE_TIER_CARD_CONFIG[tier];
   let features = ENGINE_TIER_CARD_CONFIG[tier].features;
   if (tier === "PREMIUM") {
-    features = [...ENGINE_TIER_CARD_CONFIG.STANDARD.features, ...features];
+    features = [...ENGINE_TIER_CARD_CONFIG.STARTER.features, ...features];
   }
 
   const defaultCtaText =

--- a/src/components/homepage/sections/PricingEngine.tsx
+++ b/src/components/homepage/sections/PricingEngine.tsx
@@ -32,7 +32,7 @@ export const PricingEngineHomepage: React.FC<PricingSectionProps> = ({
         </Flex>
         <SimpleGrid columns={{ base: 1, lg: 3 }} gap={6}>
           <EngineTierCard
-            tier="STANDARD"
+            tier="STARTER"
             ctaText="Get Started"
             onClick={() => {
               track({

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -351,7 +351,7 @@ const EnginePricing = ({ isMobile }: { isMobile: boolean }) => {
       </Text>
       <SimpleGrid columns={isMobile ? 1 : 3} gap={6}>
         <EngineTierCard
-          tier="STANDARD"
+          tier="STARTER"
           ctaText="Get Started"
           onClick={() => {
             track({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates pricing tiers from "STANDARD" to "STARTER" across components and hooks.

### Detailed summary
- Updated `EngineTier` type to include "STARTER"
- Renamed pricing tier configurations from "STANDARD" to "STARTER"
- Adjusted default engine tier to "STARTER"
- Modified modal messages and prices to reflect "STARTER" tier changes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->