### PR TITLE
Fallback to inputted address on failed ens resolution

### DIFF
--- a/src/components/contract-components/hooks.ts
+++ b/src/components/contract-components/hooks.ts
@@ -958,7 +958,14 @@ export function ensQuery(addressOrEnsName?: string) {
         throw new Error("Invalid address or ENS name.");
       }
 
-      const { address, ensName } = await resolveEns(addressOrEnsName);
+      const { address, ensName } = await resolveEns(addressOrEnsName).catch(
+        () => ({
+          address: utils.isAddress(addressOrEnsName || "")
+            ? addressOrEnsName || null
+            : null,
+          ensName: null,
+        }),
+      );
 
       if (isEnsName(addressOrEnsName) && !address) {
         throw new Error("Failed to resolve ENS name.");


### PR DESCRIPTION
Fixes CNCT-1235

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error handling in the `resolveEns` function by adding a `catch` block to handle errors and ensure `address` and `ensName` are properly set.

### Detailed summary
- Added a `catch` block to handle errors in `resolveEns` function
- Sets `address` based on `addressOrEnsName` validity
- Sets `ensName` to `null` if error occurs

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->