### PR TITLE
Fix deterministic deployment for zksync

### DIFF
--- a/src/components/contract-components/hooks.ts
+++ b/src/components/contract-components/hooks.ts
@@ -701,18 +701,45 @@ export function useCustomContractDeployMutation(
             fullPublishMetadata?.data?.compilers?.zksolc ||
             rawPredeployMetadata?.data?.compilers?.zksolc
           ) {
-            contractAddress = await zkDeployContractFromUri(
-              ipfsHash.startsWith("ipfs://") ? ipfsHash : `ipfs://${ipfsHash}`,
-              Object.values(data.deployParams),
-              zkSigner,
-              StorageSingleton,
-              chainId as number,
-              {
-                compilerOptions: {
-                  compilerType: "zksolc",
+            if (data.deployDeterministic) {
+              const salt = data.signerAsSalt
+                ? (await signer?.getAddress())?.concat(
+                    data.saltForCreate2 || "",
+                  )
+                : data.saltForCreate2;
+
+              contractAddress = await zkDeployContractFromUri(
+                ipfsHash.startsWith("ipfs://")
+                  ? ipfsHash
+                  : `ipfs://${ipfsHash}`,
+                Object.values(data.deployParams),
+                zkSigner,
+                StorageSingleton,
+                chainId as number,
+                {
+                  compilerOptions: {
+                    compilerType: "zksolc",
+                  },
+                  saltForProxyDeploy: salt,
                 },
-              },
-            );
+                true,
+              );
+            } else {
+              contractAddress = await zkDeployContractFromUri(
+                ipfsHash.startsWith("ipfs://")
+                  ? ipfsHash
+                  : `ipfs://${ipfsHash}`,
+                Object.values(data.deployParams),
+                zkSigner,
+                StorageSingleton,
+                chainId as number,
+                {
+                  compilerOptions: {
+                    compilerType: "zksolc",
+                  },
+                },
+              );
+            }
           } else {
             contractAddress = await zkDeployContractFromUri(
               ipfsHash.startsWith("ipfs://") ? ipfsHash : `ipfs://${ipfsHash}`,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the contract deployment logic in `hooks.ts` to support deterministic contract deployment using a salt value.

### Detailed summary
- Added support for deterministic contract deployment using a salt value
- Updated contract deployment logic based on `data.deployDeterministic` flag
- Modified the parameters passed to `zkDeployContractFromUri` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->