### PR TITLE
[WIP] test zksigner with safe

### DIFF
--- a/src/components/contract-components/hooks.ts
+++ b/src/components/contract-components/hooks.ts
@@ -56,7 +56,7 @@ import {
 } from "@thirdweb-dev/sdk/evm/zksync";
 import { walletIds } from "@thirdweb-dev/wallets";
 import { SnippetApiResponse } from "components/contract-tabs/code/types";
-import { providers, utils } from "ethers";
+import { utils } from "ethers";
 import { useSupportedChain } from "hooks/chains/configureChains";
 import { isEnsName, resolveEns } from "lib/ens";
 import { getDashboardChainRpc } from "lib/rpc";
@@ -64,9 +64,8 @@ import { StorageSingleton, getThirdwebSDK } from "lib/sdk";
 import { StaticImageData } from "next/image";
 import { useMemo } from "react";
 import invariant from "tiny-invariant";
-import { Web3Provider, Signer as ZkSigner } from "zksync-ethers";
+import { Signer as ZkSigner } from "zksync-ethers";
 import { z } from "zod";
-import { useActiveWallet } from "thirdweb/react";
 
 const HEADLESS_WALLET_IDS: string[] = [
   walletIds.localWallet,

--- a/src/components/contract-components/hooks.ts
+++ b/src/components/contract-components/hooks.ts
@@ -29,6 +29,7 @@ import {
   useSDK,
   useSDKChainId,
   useSigner,
+  useWallet,
   useWalletConfig,
 } from "@thirdweb-dev/react";
 import { FeatureWithEnabled } from "@thirdweb-dev/sdk/dist/declarations/src/evm/constants/contract-features";
@@ -63,8 +64,9 @@ import { StorageSingleton, getThirdwebSDK } from "lib/sdk";
 import { StaticImageData } from "next/image";
 import { useMemo } from "react";
 import invariant from "tiny-invariant";
-import { Web3Provider } from "zksync-ethers";
+import { Web3Provider, Signer as ZkSigner } from "zksync-ethers";
 import { z } from "zod";
+import { useActiveWallet } from "thirdweb/react";
 
 const HEADLESS_WALLET_IDS: string[] = [
   walletIds.localWallet,
@@ -596,6 +598,7 @@ export function useCustomContractDeployMutation(
   const { data: transactions } = useTransactionsForDeploy(ipfsHash);
   const fullPublishMetadata = useContractFullPublishMetadata(ipfsHash);
   const rawPredeployMetadata = useContractRawPredeployMetadataFromURI(ipfsHash);
+  const activeWallet = useWallet();
 
   const walletConfig = useWalletConfig();
 
@@ -691,11 +694,9 @@ export function useCustomContractDeployMutation(
           chainId === ZksyncEraGoerliTestnetDeprecated.chainId;
 
         // deploy contract
-        if (isZkSync) {
+        if (isZkSync && activeWallet?.walletId !== "safe-wallet") {
           // Get metamask signer using zksync-ethers library -- for custom fields in signature
-          const zkSigner = new Web3Provider(
-            window.ethereum as unknown as providers.ExternalProvider,
-          ).getSigner();
+          const zkSigner = ZkSigner.from(signer as any);
 
           if (
             fullPublishMetadata?.data?.compilers?.zksolc ||


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `useWallet` hook and updates the `useCustomContractDeployMutation` function to use the `activeWallet` instead of `Web3Provider`.

### Detailed summary
- Added `useWallet` hook
- Replaced `Web3Provider` with `ZkSigner` in `useCustomContractDeployMutation`
- Updated dependencies and imports

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->