### PR TITLE
chore: query supported chains from chainsaw

### DIFF
--- a/src/contract-ui/tabs/analytics/page.tsx
+++ b/src/contract-ui/tabs/analytics/page.tsx
@@ -22,8 +22,8 @@ import { BarChart } from "components/analytics/bar-chart";
 import { ChartContainer } from "components/analytics/chart-container";
 import {
   AnalyticsQueryParams,
-  SUPPORTED_ANALYTICS_CHAINS,
   TotalQueryResult,
+  useAnalyticsSupportedChains,
   useEventsAnalytics,
   useFunctionsAnalytics,
   useLogsAnalytics,
@@ -242,6 +242,8 @@ export const AnalyticsChart: React.FC<AnalyticsChartProps> = ({
   showXAxis,
   showYAxis,
 }) => {
+  const supportedChainsQuery = useAnalyticsSupportedChains();
+
   const analyticsQuery = useAnalytics({
     contractAddress,
     chainId,
@@ -258,10 +260,12 @@ export const AnalyticsChart: React.FC<AnalyticsChartProps> = ({
   }, [analyticsQuery.data]);
 
   if (data.length <= 1) {
+    const supportedChains = supportedChainsQuery.data ?? [];
+
     return (
       <Alert status="info" borderRadius="md" mb={4}>
         <AlertIcon />
-        {SUPPORTED_ANALYTICS_CHAINS.includes(chainId) ? (
+        {supportedChains.includes(chainId) ? (
           <AlertDescription>No recent activity.</AlertDescription>
         ) : (
           <AlertDescription>

--- a/src/data/analytics/hooks.ts
+++ b/src/data/analytics/hooks.ts
@@ -1,23 +1,5 @@
-import { THIRDWEB_ANALYTICS_API_HOSTNAME } from "./constants";
 import { useQuery } from "@tanstack/react-query";
-import {
-  Arbitrum,
-  ArbitrumGoerli,
-  Avalanche,
-  AvalancheFuji,
-  Base,
-  BaseGoerli,
-  BinanceTestnet,
-  Ethereum,
-  Fantom,
-  Goerli,
-  Mumbai,
-  Optimism,
-  Polygon,
-  PolygonZkevmTestnet,
-  ScrollAlphaTestnet,
-  Sepolia,
-} from "@thirdweb-dev/chains";
+import { THIRDWEB_ANALYTICS_API_HOSTNAME } from "./constants";
 
 export type AnalyticsQueryParams = {
   chainId: number;
@@ -26,26 +8,6 @@ export type AnalyticsQueryParams = {
   endDate?: Date;
   interval?: "minute" | "hour" | "day" | "week" | "month";
 };
-
-// TODO: Keep updated with actual ClickHouse data
-export const SUPPORTED_ANALYTICS_CHAINS: number[] = [
-  Ethereum.chainId,
-  Goerli.chainId,
-  Optimism.chainId,
-  BinanceTestnet.chainId,
-  Polygon.chainId,
-  Fantom.chainId,
-  PolygonZkevmTestnet.chainId,
-  Base.chainId,
-  Arbitrum.chainId,
-  AvalancheFuji.chainId,
-  Avalanche.chainId,
-  Mumbai.chainId,
-  BaseGoerli.chainId,
-  ArbitrumGoerli.chainId,
-  ScrollAlphaTestnet.chainId,
-  Sepolia.chainId,
-];
 
 async function makeQuery(
   path: string,
@@ -403,4 +365,19 @@ export function useTotalWalletsAnalytics(params: AnalyticsQueryParams) {
     },
     enabled: !!params.contractAddress && !!params.chainId,
   });
+}
+
+export function useAnalyticsSupportedChains() {
+  return useQuery(
+    ["analytics-supported-chains"] as const,
+    async (): Promise<number[]> => {
+      const res = await makeQuery("/api/v1/supported-chains", {});
+      if (!res.ok) {
+        throw new Error(`Unexpected status ${res.status}`);
+      }
+
+      const { results } = await res.json();
+      return results;
+    },
+  );
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor the analytics page in the contract UI to use a new hook for fetching supported chains data.

### Detailed summary
- Introduced `useAnalyticsSupportedChains` hook to fetch supported chains data
- Removed `SUPPORTED_ANALYTICS_CHAINS` constant and related imports
- Updated usage of supported chains data in the `AnalyticsChart` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->