### PR TITLE
feat: add icon to ToolTipLabel in chainlist-row

### DIFF
--- a/src/app/(dashboard)/(chain)/chainlist/components/server/chainlist-row.tsx
+++ b/src/app/(dashboard)/(chain)/chainlist/components/server/chainlist-row.tsx
@@ -1,4 +1,10 @@
-import { CircleAlertIcon, TicketCheckIcon, VerifiedIcon } from "lucide-react";
+import {
+  CheckIcon,
+  CircleAlertIcon,
+  TicketCheckIcon,
+  VerifiedIcon,
+  XIcon,
+} from "lucide-react";
 import Link from "next/link";
 import { ToolTipLabel } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -101,7 +107,16 @@ function ProductIcon(props: {
   isEnabled: boolean;
 }) {
   return (
-    <ToolTipLabel label={props.label}>
+    <ToolTipLabel
+      label={props.label}
+      leftIcon={
+        props.isEnabled ? (
+          <CheckIcon className="text-success-foreground size-4" />
+        ) : (
+          <XIcon className="text-destructive-foreground size-4" />
+        )
+      }
+    >
       <Link href={props.href}>
         <props.icon className={cn("size-8", !props.isEnabled && "grayscale")} />
       </Link>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `ProductIcon` component in `chainlist-row.tsx` to display different icons based on the `isEnabled` prop.

### Detailed summary
- Added icons: `CheckIcon`, `XIcon`
- Updated `ProductIcon` to show different icons based on `isEnabled` prop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->