### PR TITLE
feat: add revalidation to fetch calls in chain-icon and utils

### DIFF
--- a/src/app/(dashboard)/(chain)/components/server/chain-icon.tsx
+++ b/src/app/(dashboard)/(chain)/components/server/chain-icon.tsx
@@ -20,6 +20,8 @@ export async function ChainIcon(props: {
       // hack to fix this bug: https://github.com/thirdweb-dev/js/pull/3241
       .replace("ipfs://", "");
     const res = await fetch(resolved, {
+      // revalidate every hour
+      next: { revalidate: 60 * 60 },
       method: "HEAD",
       cache: "force-cache",
       headers: DASHBOARD_THIRDWEB_SECRET_KEY

--- a/src/app/(dashboard)/(chain)/utils.ts
+++ b/src/app/(dashboard)/(chain)/utils.ts
@@ -14,7 +14,8 @@ import xaiCTABg from "./temp-assets/cta-bg-xai-connect.png";
 export async function getChains() {
   const response = await fetch(
     `${THIRDWEB_API_HOST}/v1/chains?includeServices=true`,
-    { next: { revalidate: 3600 } },
+    // revalidate every hour
+    { next: { revalidate: 60 * 60 } },
   );
 
   if (!response.ok) {
@@ -29,6 +30,8 @@ export async function getChain(
 ): Promise<ChainMetadataWithServices> {
   const res = await fetch(
     `${THIRDWEB_API_HOST}/v1/chains/${chainIdOrSlug}?includeServices=true`,
+    // revalidate every 15 minutes
+    { next: { revalidate: 15 * 60 } },
   );
 
   const result = await res.json();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update revalidation intervals for API fetch requests in the chain-related components and utilities.

### Detailed summary
- Updated revalidation interval to every hour in `chain-icon.tsx`
- Updated revalidation intervals in `utils.ts` to every hour and every 15 minutes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->