### PR TITLE
Show Favorite chains in NetworkSelector Button

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12017,6 +12017,7 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: false
+    bundledDependencies: false
 
   /event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}

--- a/src/@3rdweb-sdk/react/components/connect-wallet/index.tsx
+++ b/src/@3rdweb-sdk/react/components/connect-wallet/index.tsx
@@ -3,19 +3,18 @@
 /* eslint-disable react/forbid-dom-props */
 import { popularChains } from "../popularChains";
 import { useTheme } from "next-themes";
-import { ConnectWallet, useSupportedChains } from "@thirdweb-dev/react";
+import { ConnectWallet } from "@thirdweb-dev/react";
 import {
   useAddRecentlyUsedChainId,
   useRecentlyUsedChains,
 } from "hooks/chains/recentlyUsedChains";
 import { useSetIsNetworkConfigModalOpen } from "hooks/networkConfigModal";
-import { ComponentProps, useCallback, useMemo } from "react";
+import { ComponentProps, useCallback } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useTrack } from "../../../../hooks/analytics/useTrack";
 import { CustomChainRenderer } from "../../../../components/selects/CustomChainRenderer";
-import { useFavouriteChains } from "../../../../app/(dashboard)/(chain)/components/client/star-button";
-import type { Chain } from "@thirdweb-dev/chains";
+import { useFavoriteChains } from "../../hooks/useFavoriteChains";
 
 export interface ConnectWalletProps {
   shrinkMobile?: boolean;
@@ -36,22 +35,7 @@ export const CustomConnectWallet: React.FC<ConnectWalletProps> = ({
   const addRecentlyUsedChainId = useAddRecentlyUsedChainId();
   const setIsNetworkConfigModalOpen = useSetIsNetworkConfigModalOpen();
   const t = theme === "light" ? "light" : "dark";
-  const allChains = useSupportedChains();
-  const favChainsQuery = useFavouriteChains();
-
-  const favChains = useMemo(() => {
-    if (favChainsQuery.data) {
-      const _chains: Chain[] = [];
-      favChainsQuery.data.forEach((chainId) => {
-        const chain = allChains.find((c) => String(c.chainId) === chainId);
-        if (chain) {
-          _chains.push(chain);
-        }
-      });
-
-      return _chains;
-    }
-  }, [favChainsQuery.data, allChains]);
+  const favChainsQuery = useFavoriteChains();
 
   return (
     <ConnectWallet
@@ -64,8 +48,20 @@ export const CustomConnectWallet: React.FC<ConnectWalletProps> = ({
       privacyPolicyUrl="/privacy"
       hideTestnetFaucet={false}
       networkSelector={{
-        popularChains: favChains ?? popularChains,
-        recentChains,
+        sections: [
+          {
+            label: "Recently used",
+            chains: recentChains,
+          },
+          {
+            label: "Favorites",
+            chains: favChainsQuery.data ?? [],
+          },
+          {
+            label: "Popular",
+            chains: popularChains,
+          },
+        ],
         onSwitch(chain) {
           addRecentlyUsedChainId(chain.chainId);
         },

--- a/src/@3rdweb-sdk/react/hooks/useFavoriteChains.ts
+++ b/src/@3rdweb-sdk/react/hooks/useFavoriteChains.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import type { Chain } from "@thirdweb-dev/chains";
+import { useFavouriteChainIds } from "../../../app/(dashboard)/(chain)/components/client/star-button";
+import { useSupportedChains } from "@thirdweb-dev/react";
+
+export function useFavoriteChains() {
+  const allChains = useSupportedChains();
+  const favChainsQuery = useFavouriteChainIds();
+
+  const data = useMemo(() => {
+    if (favChainsQuery.data) {
+      const _chains: Chain[] = [];
+      favChainsQuery.data.forEach((chainId) => {
+        const chain = allChains.find((c) => String(c.chainId) === chainId);
+        if (chain) {
+          _chains.push(chain);
+        }
+      });
+
+      return _chains;
+    }
+
+    return [] as Chain[];
+  }, [favChainsQuery.data, allChains]);
+
+  return {
+    isLoading: favChainsQuery.isLoading,
+    data,
+  };
+}

--- a/src/app/(dashboard)/(chain)/components/client/star-button.tsx
+++ b/src/app/(dashboard)/(chain)/components/client/star-button.tsx
@@ -43,7 +43,7 @@ async function removeChainFromFavorites(chainId: number) {
   return result?.data?.favorite;
 }
 
-export function useFavouriteChains() {
+export function useFavouriteChainIds() {
   const loggedInUser = useLoggedInUser();
   return useQuery({
     queryKey: ["favoriteChains", loggedInUser.user?.address],
@@ -60,7 +60,7 @@ export function StarButton(props: {
 }) {
   const loggedInUser = useLoggedInUser();
   const queryClient = useQueryClient();
-  const favChainsQuery = useFavouriteChains();
+  const favChainsQuery = useFavouriteChainIds();
 
   const mutation = useMutation({
     mutationFn: (preferred: boolean) => {

--- a/src/components/selects/NetworkSelectorButton.tsx
+++ b/src/components/selects/NetworkSelectorButton.tsx
@@ -13,6 +13,7 @@ import { useSetIsNetworkConfigModalOpen } from "hooks/networkConfigModal";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { BiChevronDown } from "react-icons/bi";
 import { Button } from "tw-components";
+import { useFavoriteChains } from "../../@3rdweb-sdk/react/hooks/useFavoriteChains";
 
 interface NetworkSelectorButtonProps {
   disabledChainIds?: number[];
@@ -33,6 +34,7 @@ export const NetworkSelectorButton: React.FC<NetworkSelectorButtonProps> = ({
   const setIsNetworkConfigModalOpen = useSetIsNetworkConfigModalOpen();
   const { colorMode } = useColorMode();
   const supportedChains = useSupportedChains();
+  const favoriteChainsQuery = useFavoriteChains();
 
   const chains = useMemo(() => {
     if (disabledChainIds && disabledChainIds.length > 0) {
@@ -123,8 +125,20 @@ export const NetworkSelectorButton: React.FC<NetworkSelectorButtonProps> = ({
           open={showNetworkSelector}
           theme={colorMode}
           chains={chains}
-          recentChains={filteredRecentlyUsedChains}
-          popularChains={networksEnabled ? undefined : popularChains}
+          sections={[
+            {
+              label: "Recently Used",
+              chains: filteredRecentlyUsedChains ?? [],
+            },
+            {
+              label: "Favorites",
+              chains: favoriteChainsQuery.data ?? [],
+            },
+            {
+              label: "Popular",
+              chains: networksEnabled ? [] : popularChains,
+            },
+          ]}
           renderChain={CustomChainRenderer}
           onCustomClick={
             networksEnabled


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor and update the handling of favorite chains in the application.

### Detailed summary
- Renamed `useFavouriteChains` to `useFavouriteChainIds`
- Added `bundledDependencies: false` in `pnpm-lock.yaml`
- Updated usage of favorite chains in various components
- Added a new hook `useFavoriteChains` to fetch and handle favorite chains efficiently

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->