### PR TITLE
Enable deployment for zkcandy sepolia testnet

### DIFF
--- a/src/components/contract-components/hooks.ts
+++ b/src/components/contract-components/hooks.ts
@@ -18,6 +18,7 @@ import {
 } from "@tanstack/react-query";
 import {
   Polygon,
+  ZkcandySepoliaTestnet,
   Zksync,
   ZksyncEraGoerliTestnetDeprecated,
   ZksyncSepoliaTestnet,
@@ -688,6 +689,7 @@ export function useCustomContractDeployMutation(
         const isZkSync =
           chainId === Zksync.chainId ||
           chainId === ZksyncSepoliaTestnet.chainId ||
+          chainId === ZkcandySepoliaTestnet.chainId ||
           chainId === ZksyncEraGoerliTestnetDeprecated.chainId;
 
         // deploy contract


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `ZkcandySepoliaTestnet` chain and updates the `useCustomContractDeployMutation` function to include it as a valid chain ID.

### Detailed summary
- Added `ZkcandySepoliaTestnet` chain
- Updated `useCustomContractDeployMutation` to include `ZkcandySepoliaTestnet` as a valid chain ID

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->