### PR TITLE
refactor: remove force-cache from ChainIcon fetch method

### DIFF
--- a/src/app/(dashboard)/(chain)/components/server/chain-icon.tsx
+++ b/src/app/(dashboard)/(chain)/components/server/chain-icon.tsx
@@ -23,7 +23,6 @@ export async function ChainIcon(props: {
       // revalidate every hour
       next: { revalidate: 60 * 60 },
       method: "HEAD",
-      cache: "force-cache",
       headers: DASHBOARD_THIRDWEB_SECRET_KEY
         ? {
             "x-secret-key": DASHBOARD_THIRDWEB_SECRET_KEY,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `chain-icon.tsx` file in the `server` folder of the `dashboard` component to include a new header `x-secret-key` with a value from `DASHBOARD_THIRDWEB_SECRET_KEY`.

### Detailed summary
- Added a new header `x-secret-key` with value from `DASHBOARD_THIRDWEB_SECRET_KEY`.
- Updated caching strategy to "force-cache".
- Set method to "HEAD" for the request.
- Added `revalidate` option with a value of 3600 seconds.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->