### PR TITLE
Show asset contract address in listing-drawer

### DIFF
--- a/src/contract-ui/tabs/shared-components/listing-drawer.tsx
+++ b/src/contract-ui/tabs/shared-components/listing-drawer.tsx
@@ -57,6 +57,16 @@ export const ListingDrawer: React.FC<NFTDrawerProps> = ({
             <Card as={Flex} flexDir="column" gap={3}>
               <SimpleGrid rowGap={3} columns={12} placeItems="center left">
                 <GridItem colSpan={3}>
+                  <Heading size="label.md">Asset contract address</Heading>
+                </GridItem>
+                <GridItem colSpan={9}>
+                  <AddressCopyButton
+                    size="xs"
+                    address={renderData.assetContractAddress}
+                    title="contract address"
+                  />
+                </GridItem>
+                <GridItem colSpan={3}>
                   <Heading size="label.md">Token ID</Heading>
                 </GridItem>
                 <GridItem colSpan={9}>


### PR DESCRIPTION
<img width="442" alt="image" src="https://github.com/thirdweb-dev/dashboard/assets/26052673/d4bc3298-c5e1-4360-8127-358f35fd2230">

smol change to improve ux

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the listing drawer in the contract UI by adding an `AddressCopyButton` component for the asset contract address.

### Detailed summary
- Added `AddressCopyButton` component for asset contract address
- Styled the layout with `GridItem` components for better organization

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->