### PR TITLE
feat: add eslint rule to warn against useEffect

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,6 +99,14 @@ module.exports = {
     "inclusive-language/use-inclusive-words": "error",
     // turn off deprecated things?
     "react/react-in-jsx-scope": "off",
+    "no-restricted-syntax": [
+      "warn",
+      {
+        selector: "CallExpression[callee.name='useEffect']",
+        message:
+          'Are you *sure* you need to use "useEffect" here? If you loading any async function prefer using "useQuery".',
+      },
+    ],
     "no-restricted-imports": [
       "error",
       {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new ESLint rule to warn against using `useEffect` for async functions, suggesting `useQuery` instead.

### Detailed summary
- Added ESLint rule to warn against using `useEffect` for async functions
- Rule message suggests using `useQuery` for async operations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->