### PR TITLE
chore: change `no-restricted-syntax` rule for `useEffect` selector to error in .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -100,7 +100,7 @@ module.exports = {
     // turn off deprecated things?
     "react/react-in-jsx-scope": "off",
     "no-restricted-syntax": [
-      "warn",
+      "error",
       {
         selector: "CallExpression[callee.name='useEffect']",
         message:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the ESLint configuration to change the severity level of the `no-restricted-syntax` rule from "warn" to "error".

### Detailed summary
- Changed severity level of `no-restricted-syntax` rule from "warn" to "error" in `.eslintrc.js`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->