### PR TITLE
feat: add support for extension-based code snippets in ContractFunction and CodeOverview components

### DIFF
--- a/src/components/contract-functions/contract-function.tsx
+++ b/src/components/contract-functions/contract-function.tsx
@@ -51,6 +51,21 @@ const ContractFunction: React.FC<ContractFunctionProps> = ({
 }) => {
   const [environment, setEnvironment] = useState<CodeEnvironment>("javascript");
 
+  const enabledExtensions = useContractEnabledExtensions(contract?.abi);
+
+  const extensionNamespace = useMemo(() => {
+    if (enabledExtensions.some((e) => e.name === "ERC20")) {
+      return "erc20";
+    }
+    if (enabledExtensions.some((e) => e.name === "ERC721")) {
+      return "erc721";
+    }
+    if (enabledExtensions.some((e) => e.name === "ERC1155")) {
+      return "erc1155";
+    }
+    return undefined;
+  }, [enabledExtensions]);
+
   if (!fn) {
     return null;
   }
@@ -171,6 +186,7 @@ const ContractFunction: React.FC<ContractFunctionProps> = ({
             fn,
             args: fn.inputs?.map((i) => i.name),
             chainId: contract?.chainId,
+            extensionNamespace,
           },
         )}
       />


### PR DESCRIPTION
### What changed?

This PR introduces several key enhancements to the `ContractFunction` and `CodeOverview` components:

1. **Environment Selection**: A new `extensionNamespace` state is added based on the enabled extensions in the contract ABI (`ERC20`, `ERC721`, `ERC1155`). This state determines the namespace used for different contract extensions.

2. **Code Snippets Generation**: Functions `buildJavascriptSnippet` and `buildReactSnippet` are added to dynamically generate code snippets based on the extension namespace and contract function type (read, write, event).

3. **Snippet Formatting**: The `formatSnippet` function is modified to include the newly generated code snippets, replacing placeholders with actual values.

### How to test?

1. **Setup**: Ensure you have a contract with varying enabled extensions (`ERC20`, `ERC721`, `ERC1155`).

2. **Test Snippet Generation**: For each contract, navigate to the code overview and ensure the generated snippets correspond to the contract's extensions and function types.

3. **Verify Placeholder Replacement**: Confirm that placeholders in the code (`{{contract_address}}`, `{{wallet_address}}`, etc.) are correctly replaced with real values.

### Why make this change?

This update enhances the flexibility and readability of the code snippets provided to developers, making it easier to interact with contract functions by displaying relevant code based on the contract's supported extensions and environment.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to introduce code snippets generation for different extensions based on contract functions.

### Detailed summary
- Added functions to build JavaScript and React code snippets for different extensions
- Introduced mapping for extension namespaces and functions
- Updated snippet formatting based on extension and function details

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->