### PR TITLE
Fix pricing card height on safari

### DIFF
--- a/src/components/homepage/sections/PricingCard.tsx
+++ b/src/components/homepage/sections/PricingCard.tsx
@@ -53,7 +53,6 @@ export const PricingCard: React.FC<PricingCardProps> = ({
       gap={10}
       flexDir="column"
       p={{ base: 6, md: 10 }}
-      h="full"
       zIndex={999}
       background={highlighted ? "black" : "transparent"}
       borderColor={current ? "blue.500" : "gray.900"}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the styling of the `PricingCard` component to improve readability and visual hierarchy.

### Detailed summary
- Changed `flexDir` to "column" for better layout
- Adjusted padding values for different screen sizes
- Set height to "full"
- Increased `zIndex` to 999 for layering
- Updated background color based on `highlighted` prop
- Changed border color based on `current` prop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->