### PR TITLE
refactor: remove unused 'lottie' prop from LandingHero component

### DIFF
--- a/src/components/landing-pages/hero.tsx
+++ b/src/components/landing-pages/hero.tsx
@@ -13,7 +13,6 @@ interface LandingHeroProps {
   trackingCategory: string;
   ctaText?: string;
   ctaLink?: string;
-  lottie?: {};
   gradient: string;
   image?: StaticImageData;
   mobileImage?: StaticImageData;
@@ -31,7 +30,6 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
   ctaText,
   ctaLink,
   gradient,
-  lottie,
   image,
   mobileImage,
   noCta,
@@ -81,13 +79,6 @@ export const LandingHero: React.FC<LandingHeroProps> = ({
             trackingCategory={trackingCategory}
             contactUsTitle={contactUsTitle}
             contactUsLink={contactUsLink}
-          />
-        </Flex>
-        <Flex maxH="500px">
-          <LandingDesktopMobileImage
-            lottie={lottie}
-            image={image}
-            mobileImage={mobileImage}
           />
         </Flex>
       </Container>


### PR DESCRIPTION
### TL;DR

Removed the `lottie` animation support in the `LandingHero` component.

### What changed?

- Deleted the `lottie` property from the `LandingHeroProps` interface.
- Removed `lottie` from the `LandingHero` component's destructured props.
- Deleted the `Flex` container that previously contained the `LandingDesktopMobileImage` with the `lottie` prop.

### How to test?

1. Verify that the `LandingHero` component no longer expects or handles the `lottie` prop.
2. Ensure that there are no visual or functional regressions in the `LandingHero` component on various pages where it is used.

### Why make this change?

The `lottie` animation support was deemed unnecessary and has been removed to streamline the component's implementation and reduce complexity.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `lottie` prop from `LandingHero` component and refactors the rendering of images.

### Detailed summary
- Removed `lottie` prop from `LandingHero`
- Refactored image rendering in `LandingHero` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->