### PR TITLE
feat: update AnnouncementBanner with Blocktorch acquisition details

### DIFF
--- a/src/components/notices/AnnouncementBanner.tsx
+++ b/src/components/notices/AnnouncementBanner.tsx
@@ -5,7 +5,7 @@ import { Heading, TrackedLink } from "tw-components";
 
 export const AnnouncementBanner = () => {
   const [hasDismissedAnnouncement, setHasDismissedAnnouncement] =
-    useLocalStorage("dismissed-thirdweb-pay", false, true);
+    useLocalStorage("dismissed-blocktorch-announcement", false, true);
 
   if (hasDismissedAnnouncement) {
     return null;
@@ -27,9 +27,10 @@ export const AnnouncementBanner = () => {
       >
         <Box display={{ base: "none", md: "block" }} />
         <TrackedLink
-          href="https://pay-demo.thirdweb.com/"
+          href="https://blog.thirdweb.com/welcoming-blocktorch/"
           category="announcement"
-          label="thirdweb-pay"
+          label="blocktorch"
+          isExternal
         >
           <Container maxW="container.page" display="flex" px={0}>
             <Flex
@@ -46,8 +47,8 @@ export const AnnouncementBanner = () => {
                 color="white"
                 fontWeight={500}
               >
-                Introducing thirdweb Pay: Onramp users to your app with credit
-                card & cross-chain crypto. Integrate for free
+                thirdweb acquires Blocktorch, a leading web3 observability
+                platform.
               </Heading>
               <Icon display={{ base: "none", md: "block" }} as={FiArrowRight} />
             </Flex>


### PR DESCRIPTION
### TL;DR

Update AnnouncementBanner to reflect the acquisition of Blocktorch by thirdweb, including new link, label, and announcement text.

### What changed?

- Modified `useLocalStorage` key from `dismissed-thirdweb-pay` to `dismissed-blocktorch-announcement`.
- Updated the link in `TrackedLink` from `pay-demo.thirdweb.com` to the blog post regarding the acquisition of Blocktorch: `blog.thirdweb.com/welcoming-blocktorch/`.
- Changed the label in `TrackedLink` from `thirdweb-pay` to `blocktorch`.
- Added `isExternal` attribute to `TrackedLink`.
- Revised the announcement text from "Introducing thirdweb Pay" to "thirdweb acquires Blocktorch, a leading web3 observability platform." 

### How to test?

- Verify that the AnnouncementBanner displays the new text regarding the Blocktorch acquisition.
- Check that clicking the link directs to the Blocktorch acquisition blog post.
- Ensure that the local storage key is correctly updated to `dismissed-blocktorch-announcement`.

### Why make this change?

To inform users about the recent acquisition of Blocktorch by thirdweb and update the relevant link, label, and text in the AnnouncementBanner to reflect this update.

---

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the AnnouncementBanner component with new content and links related to the acquisition of Blocktorch by thirdweb.

### Detailed summary
- Updated `useLocalStorage` key to `dismissed-blocktorch-announcement`
- Changed link and label to reflect the acquisition news
- Updated the announcement content to reflect the acquisition of Blocktorch by thirdweb

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->