### PR TITLE
refactor: prevent HTML files from being dropped in IpfsUploadDropzone component

### DIFF
--- a/src/components/ipfs-upload/dropzone.tsx
+++ b/src/components/ipfs-upload/dropzone.tsx
@@ -50,7 +50,11 @@ export const IpfsUploadDropzone: React.FC<IpfsUploadDropzoneProps> = () => {
   const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop: (files) => setDroppedFiles((prev) => [...prev, ...files]),
+    onDrop: (files) =>
+      setDroppedFiles((prev) => [
+        ...prev,
+        ...files.filter((f) => f.type !== "text/html"),
+      ]),
   });
   return (
     <Flex flexDir="column" gap={4}>


### PR DESCRIPTION
### TL;DR

This PR filters out HTML files from being uploaded via the IPFS upload dropzone component. This ensures users cannot upload HTML files by mistake or with malicious intent.

### What changed?

- Updated the `onDrop` method in `IpfsUploadDropzone` component to filter out `.html` files.

### How to test?

1. Go to the IPFS upload dropzone component.
2. Attempt to upload a mix of file types, including `.html` files.
3. Verify that `.html` files are not accepted.

### Why make this change?

This change prevents potential security risks and enhances the robustness of the file upload feature.

---

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `onDrop` functionality in `dropzone.tsx` to filter out files with the type "text/html".

### Detailed summary
- Updated `onDrop` function to filter out files with type "text/html" before adding to `droppedFiles` array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->